### PR TITLE
Enable nullable reference types and optimise navigation

### DIFF
--- a/DSoft.WizardControl.Core/DSoft.WizardControl.Core.csproj
+++ b/DSoft.WizardControl.Core/DSoft.WizardControl.Core.csproj
@@ -1,18 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <Version>1.3.0</Version>
-    <Description>DSoft.WizardControl.Core is a core library for DSoft.WizardControl.WPF</Description>
-    <PackageTags>WPF Wizard</PackageTags>
-    <PackageReleaseNotes>Initial Release
-    </PackageReleaseNotes>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<Product>$(AssemblyName) ($(TargetFramework))</Product>
+		<Version>1.3.0</Version>
+		<Description>DSoft.WizardControl.Core is a core library for DSoft.WizardControl.WPF</Description>
+		<PackageTags>WPF Wizard</PackageTags>
+		<PackageReleaseNotes>
+			Initial Release
+		</PackageReleaseNotes>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
-	
+
 </Project>

--- a/DSoft.WizardControl.Core/IWizardControl.cs
+++ b/DSoft.WizardControl.Core/IWizardControl.cs
@@ -29,10 +29,17 @@ namespace DSoft.WizardControl.Core
 		void UpdateButtonVisibility(WizardButtonVisibility visibility, params WizardButtons[] buttons);
 
 		/// <summary>
-		/// Updates the stage.
+		/// Updates the button style.
 		/// </summary>
-		/// <param name="stage">The stage.</param>
-		void UpdateStage(WizardStage stage);
+		/// <param name="buttons">The buttons.</param>
+		/// <param name="styleKey">The style key (name).</param>
+		void UpdateButtonStyle(WizardButtons buttons, string styleKey);
+
+        /// <summary>
+        /// Updates the stage.
+        /// </summary>
+        /// <param name="stage">The stage.</param>
+        void UpdateStage(WizardStage stage);
 
 		/// <summary>
 		/// Recalculates the navigation.

--- a/DSoft.WizardControl.Core/WizardPageConfiguration.cs
+++ b/DSoft.WizardControl.Core/WizardPageConfiguration.cs
@@ -13,7 +13,7 @@ namespace DSoft.WizardControl.Core
 		/// Gets or sets the title.
 		/// </summary>
 		/// <value>The title.</value>
-		public string Title { get; set; }
+		public string? Title { get; set; }
 
 		/// <summary>
 		/// Gets or sets a value indicating whether this instance is hidden.
@@ -37,13 +37,13 @@ namespace DSoft.WizardControl.Core
 		/// Called when the page navigation is occuring
 		/// </summary>
 		/// <value>The navigation handler.</value>
-		public Action<WizardNavigationEventArgs> NavigationHandler { get; set; }
+		public Action<WizardNavigationEventArgs>? NavigationHandler { get; set; }
 
 		/// <summary>
 		/// Gets or sets the on page shown handler.
 		/// </summary>
 		/// <value>The on page shown handler.</value>
-		public Action<IWizardControl> OnPageShownHandler { get; set; }
+		public Action<IWizardControl>? OnPageShownHandler { get; set; }
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="WizardPageConfiguration"/> class.

--- a/DSoft.WizardControl.WPF/DSoft.WizardControl.WPF.csproj
+++ b/DSoft.WizardControl.WPF/DSoft.WizardControl.WPF.csproj
@@ -23,6 +23,7 @@
 		<Compile Include="..\DSoft.WizardControl.WinUI\DefaultErrorView.uwp.winui.wpf.cs" Link="DefaultErrorView.uwp.winui.wpf.cs" />
 		<Compile Include="..\DSoft.WizardControl.WinUI\DefaultProgressView.uwp.winui.wpf.cs" Link="DefaultProgressView.uwp.winui.wpf.cs" />
 		<Compile Include="..\DSoft.WizardControl.WinUI\DelegateCommand.shared.cs" Link="DelegateCommand.shared.cs" />
+		<Compile Include="..\DSoft.WizardControl.WinUI\WizardButtonState.shared.cs" Link="WizardButtonState.shared.cs" />
 		<Compile Include="..\DSoft.WizardControl.WinUI\WizardControl.uwp.winui.wpf.cs" Link="WizardControl.uwp.winui.wpf.cs" />
 	</ItemGroup>
 

--- a/DSoft.WizardControl.WPF/README.md
+++ b/DSoft.WizardControl.WPF/README.md
@@ -90,7 +90,9 @@ Below is an example ViewModel using `System.Mvvm`
 
 The appearance of the `WizardControl` header can be modified by overriding the theme
 
-You can also change the `ButtonStyle` in the same way
+You can also change the `ButtonStyle` in the same way. Whilst `ButtonStyle` can be used to assign one button style to all visible buttons,
+individual button styles can be set as well. For individual button styles use code-behind, 
+e.g. `wizard.UpdateButtonStyle(ButtonType.Next, "WizardRedButtonStyle");` or via property binding, e.g. `NextButtonStyle="{StaticResource WizardRedButtonStyle}"`.
 
 Example styling xaml that can be added to the App.xaml or other xaml resource file
 

--- a/DSoft.WizardControl.WPF/Themes/Generic.xaml
+++ b/DSoft.WizardControl.WPF/Themes/Generic.xaml
@@ -48,11 +48,11 @@
 
 
                         <StackPanel x:Name="PART_BUTTONROW" Grid.Row="2"  Orientation="Horizontal" HorizontalAlignment="Right" Margin="5" Visibility="{TemplateBinding ButtonStackVisibility}">
-                            <Button Name="PART_BTN_PREVIOUS"  Content="{TemplateBinding PreviousButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding PreviousEnabled}" Command="{TemplateBinding PreviousCommand}" Visibility="{TemplateBinding PreviousButtonVisibility}"/>
-                            <Button Name="PART_BTN_NEXT"  Content="{TemplateBinding NextButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding NextEnabled}" Command="{TemplateBinding NextCommand}" Visibility="{TemplateBinding NextButtonVisibility}"/>
-                            <Button Name="PART_BTN_FINISH" Content="{TemplateBinding ProcessButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding ProcessEnabled}" Command="{TemplateBinding ProcessButtonCommand}" Visibility="{TemplateBinding ProcessButtonVisibility}" />
-                            <Button Name="PART_BTN_CANCEL"  Content="{TemplateBinding CancelButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding CancelEnabled}" Command="{TemplateBinding CancelCommand}"  Visibility="{TemplateBinding CancelButtonVisibility}" />
-                            <Button Name="PART_BTN_COMPLETE" Content="{TemplateBinding CloseButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding CompleteEnabled}" Command="{TemplateBinding CompleteCommand}"  Visibility="{TemplateBinding CompleteButtonVisibility}"/>
+                            <Button Name="PART_BTN_CANCEL"  Content="{TemplateBinding CancelButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding CancelEnabled}" Command="{TemplateBinding CancelCommand}"  Visibility="{TemplateBinding CancelButtonVisibility}" Style="{TemplateBinding CancelButtonStyle}"/>
+                            <Button Name="PART_BTN_PREVIOUS"  Content="{TemplateBinding PreviousButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding PreviousEnabled}" Command="{TemplateBinding PreviousCommand}" Visibility="{TemplateBinding PreviousButtonVisibility}" Style="{TemplateBinding PreviousButtonStyle}"/>
+                            <Button Name="PART_BTN_NEXT"  Content="{TemplateBinding NextButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding NextEnabled}" Command="{TemplateBinding NextCommand}" Visibility="{TemplateBinding NextButtonVisibility}" Style="{TemplateBinding NextButtonStyle}"/>
+                            <Button Name="PART_BTN_FINISH" Content="{TemplateBinding ProcessButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding ProcessEnabled}" Command="{TemplateBinding ProcessButtonCommand}" Visibility="{TemplateBinding ProcessButtonVisibility}" Style="{TemplateBinding ProcessButtonStyle}"/>
+                            <Button Name="PART_BTN_COMPLETE" Content="{TemplateBinding CloseButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding CompleteEnabled}" Command="{TemplateBinding CompleteCommand}"  Visibility="{TemplateBinding CompleteButtonVisibility}" Style="{TemplateBinding CompleteButtonStyle}"/>
                         </StackPanel>
                     </Grid>
                 </ControlTemplate>

--- a/DSoft.WizardControl.WinUI/DSoft.WizardControl.WinUI.csproj
+++ b/DSoft.WizardControl.WinUI/DSoft.WizardControl.WinUI.csproj
@@ -19,8 +19,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240428000" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
 		<ProjectReference Include="..\DSoft.WizardControl.Core\DSoft.WizardControl.Core.csproj" />
 	</ItemGroup>
 

--- a/DSoft.WizardControl.WinUI/DSoft.WizardControl.WinUI.csproj
+++ b/DSoft.WizardControl.WinUI/DSoft.WizardControl.WinUI.csproj
@@ -13,14 +13,15 @@
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<Description>DSoft.WizardControl.WinUI is a simple wizard custom control for WinUI 3.x</Description>
 		<PackageTags>WinUI Wizard</PackageTags>
-		<PackageReleaseNotes>Added .NET 10 support and removed support for .NET 6, 8 and 9
+		<PackageReleaseNotes>
+			Added .NET 10 support and removed support for .NET 6, 8 and 9
 		</PackageReleaseNotes>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
 		<ProjectReference Include="..\DSoft.WizardControl.Core\DSoft.WizardControl.Core.csproj" />
 	</ItemGroup>
 

--- a/DSoft.WizardControl.WinUI/DelegateCommand.shared.cs
+++ b/DSoft.WizardControl.WinUI/DelegateCommand.shared.cs
@@ -20,7 +20,7 @@ namespace DSoft.WizardControl
 		/// Gets or sets the execute changed.
 		/// </summary>
 		/// <value>The execute changed.</value>
-		public static Action<EventHandler, bool> ExecuteChanged { get; set; }
+		public static Action<EventHandler?, bool>? ExecuteChanged { get; set; }
 
 		/// <summary>
 		/// If set, the ViewModels will requery an ICommand properties when NotifyPropertyChanged is set
@@ -30,9 +30,9 @@ namespace DSoft.WizardControl
         #endregion
 
         #region Fields
-        private ExecuteMethod executeMethod;
-        private ExecuteMethodWithParameter executeMethodWithParam;
-        private Func<object, bool> canExecute;
+        private ExecuteMethod? executeMethod;
+        private ExecuteMethodWithParameter? executeMethodWithParam;
+        private Func<object?, bool>? canExecute;
 		#endregion
 
 		#region Properties
@@ -44,7 +44,7 @@ namespace DSoft.WizardControl
 		/// Delegate ExecuteMethodWithParameter
 		/// </summary>
 		/// <param name="parameter">The parameter.</param>
-		public delegate void ExecuteMethodWithParameter(object parameter);
+		public delegate void ExecuteMethodWithParameter(object? parameter);
 		#endregion
 
 		#region Events
@@ -54,7 +54,7 @@ namespace DSoft.WizardControl
 		/// Occurs when changes occur that affect whether or not the command should execute.
 		/// </summary>
 		/// <returns></returns>
-		public event EventHandler CanExecuteChanged
+		public event EventHandler? CanExecuteChanged
         {
             add
             {
@@ -94,7 +94,7 @@ namespace DSoft.WizardControl
 		/// </summary>
 		/// <param name="exec">The execute method</param>
 		/// <param name="canExecutePredicate">Predicate Function with object parameter</param>
-		public DelegateCommand(ExecuteMethod exec, Func<object, bool> canExecutePredicate)
+		public DelegateCommand(ExecuteMethod exec, Func<object?, bool> canExecutePredicate)
             : this(exec)
         {
             canExecute = canExecutePredicate;
@@ -105,7 +105,7 @@ namespace DSoft.WizardControl
 		/// </summary>
 		/// <param name="exec">The execute method that takes a parameter</param>
 		/// <param name="canExecutePredicate">Predicate Function with object parameter</param>
-		public DelegateCommand(ExecuteMethodWithParameter exec, Func<object, bool> canExecutePredicate)
+		public DelegateCommand(ExecuteMethodWithParameter exec, Func<object?, bool> canExecutePredicate)
             : this(exec)
         {
             canExecute = canExecutePredicate;
@@ -148,7 +148,7 @@ namespace DSoft.WizardControl
 		/// </summary>
 		/// <param name="parameter">Data used by the command.  If the command does not require data to be passed, this object can be set to null.</param>
 		/// <returns>true if this command can be executed; otherwise, false.</returns>
-		public bool CanExecute(object parameter)
+		public bool CanExecute(object? parameter)
         {
             if (canExecute == null)
             {
@@ -164,7 +164,7 @@ namespace DSoft.WizardControl
 		/// Defines the method to be called when the command is invoked.
 		/// </summary>
 		/// <param name="parameter">Data used by the command.  If the command does not require data to be passed, this object can be set to null.</param>
-		public void Execute(object parameter)
+		public void Execute(object? parameter)
         {
             if (executeMethod != null)
                 executeMethod();

--- a/DSoft.WizardControl.WinUI/Themes/Generic.xaml
+++ b/DSoft.WizardControl.WinUI/Themes/Generic.xaml
@@ -48,11 +48,11 @@
 
 
                         <StackPanel x:Name="PART_BUTTONROW" Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5" Visibility="{TemplateBinding ButtonStackVisibility}">
-                            <Button Name="PART_BTN_PREVIOUS" Content="{TemplateBinding PreviousButtonTitle}"  Margin="0,0,5,0" IsEnabled="{TemplateBinding PreviousEnabled}" Command="{TemplateBinding PreviousCommand}" Visibility="{TemplateBinding PreviousButtonVisibility}"/>
-                            <Button Name="PART_BTN_NEXT" Content="{TemplateBinding NextButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding NextEnabled}" Command="{TemplateBinding NextCommand}" Visibility="{TemplateBinding NextButtonVisibility}"/>
-                            <Button Name="PART_BTN_FINISH" Content="{TemplateBinding ProcessButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding ProcessEnabled}" Command="{TemplateBinding ProcessButtonCommand}" Visibility="{TemplateBinding ProcessButtonVisibility}" />
-                            <Button Name="PART_BTN_CANCEL"  Content="{TemplateBinding CancelButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding CancelEnabled}" Command="{TemplateBinding CancelCommand}"  Visibility="{TemplateBinding CancelButtonVisibility}" />
-                            <Button Name="PART_BTN_COMPLETE" Content="{TemplateBinding CloseButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding CompleteEnabled}" Command="{TemplateBinding CompleteCommand}"  Visibility="{TemplateBinding CompleteButtonVisibility}"/>
+                            <Button Name="PART_BTN_CANCEL"  Content="{TemplateBinding CancelButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding CancelEnabled}" Command="{TemplateBinding CancelCommand}"  Visibility="{TemplateBinding CancelButtonVisibility}" Style="{TemplateBinding CancelButtonStyle}"/>
+                            <Button Name="PART_BTN_PREVIOUS" Content="{TemplateBinding PreviousButtonTitle}"  Margin="0,0,5,0" IsEnabled="{TemplateBinding PreviousEnabled}" Command="{TemplateBinding PreviousCommand}" Visibility="{TemplateBinding PreviousButtonVisibility}" Style="{TemplateBinding PreviousButtonStyle}"/>
+                            <Button Name="PART_BTN_NEXT" Content="{TemplateBinding NextButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding NextEnabled}" Command="{TemplateBinding NextCommand}" Visibility="{TemplateBinding NextButtonVisibility}" Style="{TemplateBinding NextButtonStyle}"/>
+                            <Button Name="PART_BTN_FINISH" Content="{TemplateBinding ProcessButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding ProcessEnabled}" Command="{TemplateBinding ProcessButtonCommand}" Visibility="{TemplateBinding ProcessButtonVisibility}" Style="{TemplateBinding ProcessButtonStyle}"/>
+                            <Button Name="PART_BTN_COMPLETE" Content="{TemplateBinding CloseButtonTitle}" Margin="0,0,5,0" IsEnabled="{TemplateBinding CompleteEnabled}" Command="{TemplateBinding CompleteCommand}"  Visibility="{TemplateBinding CompleteButtonVisibility}" Style="{TemplateBinding CompleteButtonStyle}"/>
                         </StackPanel>
                     </Grid>
                 </ControlTemplate>

--- a/DSoft.WizardControl.WinUI/WizardButtonState.shared.cs
+++ b/DSoft.WizardControl.WinUI/WizardButtonState.shared.cs
@@ -1,0 +1,91 @@
+﻿using DSoft.WizardControl.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#if WPF
+using System.Windows.Controls;
+using System.Windows;
+using NativeVisibility = System.Windows.Visibility;
+#else
+using Windows.UI.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using NativeVisibility = Microsoft.UI.Xaml.Visibility;
+#endif
+
+namespace DSoft.WizardControl
+{
+    /// <summary>
+    /// Button state for the wizard buttons: visibility, current, and default style.
+    /// </summary>
+    public class WizardButtonState
+    {
+        /// <summary>
+        /// Gets or sets the button or combination of buttons displayed in the wizard interface.
+        /// </summary>
+        /// <remarks>Use this property to specify which navigation or action buttons (such as Next, Back,
+        /// Finish, or Cancel) the state relates to</remarks>
+        public WizardButtons Button { get; set; }
+
+        /// <summary>
+        /// Gets or sets the visibility state of the wizard button.
+        /// </summary>
+        public WizardButtonVisibility Visibility { get; set; }
+
+        /// <summary>
+        /// Gets or sets the style currently applied to the button.
+        /// </summary>
+        public Style ButtonStyleCurrent { get; set; }
+
+        /// <summary>
+        /// Default button style; not used at the moment but for future reference, 
+        /// e.g., if we want to reset the button style to default after changing it.
+        /// </summary>
+        public Style ButtonStyleDefault { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the WizardButtonState class with the specified button, visibility, and styles.
+        /// </summary>
+        /// <param name="button">The wizard button to which this state applies.</param>
+        /// <param name="visibility">The visibility setting for the wizard button.</param>
+        /// <param name="buttonStyleCurrent">The style to apply to the button in its current state. Can be null to use the default style.</param>
+        /// <param name="buttonStyleDefault">The default style to apply to the button when no specific style is set. Can be null.</param>
+        public WizardButtonState(WizardButtons button, WizardButtonVisibility visibility, Style buttonStyleCurrent, Style buttonStyleDefault)
+        {
+            Button = button;
+            Visibility = visibility;
+            ButtonStyleCurrent = buttonStyleCurrent;
+            ButtonStyleDefault = buttonStyleDefault;
+        }
+
+        /// <summary>
+        /// Convert WizardButtonVisibility to the native UI Framework Visibility
+        /// </summary>
+        public static NativeVisibility WizardVisibilityToVisibility(WizardButtonVisibility visibility)
+            => visibility == WizardButtonVisibility.Visible ?
+            NativeVisibility.Visible : NativeVisibility.Collapsed;
+
+        /// <summary>
+        /// Converts a NativeVisibility value to the corresponding WizardButtonVisibility value.
+        /// </summary>
+        /// <param name="visibility">The visibility state to convert.</param>
+        /// <returns>A WizardButtonVisibility value that represents the equivalent visibility state. Returns
+        /// WizardButtonVisibility.Visible if the input is NativeVisibility.Visible; otherwise, returns
+        /// WizardButtonVisibility.Collapsed.</returns>
+        public static WizardButtonVisibility VisibilityToWizardVisibility(NativeVisibility visibility)
+            => visibility == NativeVisibility.Visible ?
+            WizardButtonVisibility.Visible : WizardButtonVisibility.Collapsed;
+
+        /// <summary>
+        /// Convert WizardButtonVisibility to the native UI Framework Visibility
+        /// </summary>
+        public NativeVisibility GUIVisibility
+        {
+            get => WizardVisibilityToVisibility(Visibility);
+            set => Visibility = VisibilityToWizardVisibility(value);
+        }
+    }
+}

--- a/DSoft.WizardControl.WinUI/WizardControl.uwp.winui.wpf.cs
+++ b/DSoft.WizardControl.WinUI/WizardControl.uwp.winui.wpf.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using DSoft.WizardControl.Core;
@@ -18,17 +19,17 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace DSoft.WizardControl
 {
-	/// <summary>
-	/// Class WizardControl.
-	/// Implements the <see cref="Control" />
-	/// Implements the <see cref="IWizardControl" />
-	/// </summary>
-	/// <seealso cref="Control" />
-	/// <seealso cref="IWizardControl" />
-	public class WizardControl : Control, IWizardControl
+    /// <summary>
+    /// Class WizardControl.
+    /// Implements the <see cref="Control" />
+    /// Implements the <see cref="IWizardControl" />
+    /// </summary>
+    /// <seealso cref="Control" />
+    /// <seealso cref="IWizardControl" />
+    public class WizardControl : Control, IWizardControl
     {
-		#region Controls
-		private ContentControl _contentGrid;
+        #region Controls
+        private ContentControl _contentGrid;
         private Button _btnNext;
         private Button _btnPrevious;
         private Button _btnCancel;
@@ -37,125 +38,125 @@ namespace DSoft.WizardControl
 
         #endregion
         private WizardStage _currentStage = WizardStage.Setup;
-        private Dictionary<WizardButtons, Visibility> _buttonVisibility = new Dictionary<WizardButtons, Visibility>();
+        private Dictionary<WizardButtons, WizardButtonState> _buttonState = new Dictionary<WizardButtons, WizardButtonState>();
 
-		#region Events
+        #region Events
 
-		/// <summary>
-		/// Occurs when [on selected page changed].
-		/// </summary>
-		public event EventHandler<IWizardPage> OnSelectedPageChanged = delegate { };
-		/// <summary>
-		/// Occurs when [on selected index changed].
-		/// </summary>
-		public event EventHandler<int> OnSelectedIndexChanged = delegate { };
-		#endregion
+        /// <summary>
+        /// Occurs when [on selected page changed].
+        /// </summary>
+        public event EventHandler<IWizardPage> OnSelectedPageChanged = delegate { };
+        /// <summary>
+        /// Occurs when [on selected index changed].
+        /// </summary>
+        public event EventHandler<int> OnSelectedIndexChanged = delegate { };
+        #endregion
 
-		#region Titles and Sub-Title
+        #region Titles and Sub-Title
 
 
-		/// <summary>
-		/// The title property
-		/// </summary>
-		public readonly static DependencyProperty TitleProperty = DependencyProperty.Register("Title", typeof(string), typeof(WizardControl), new PropertyMetadata("Wizard Title", OnTitleChanged));
-		/// <summary>
-		/// The process mode property
-		/// </summary>
-		public readonly static DependencyProperty ProcessModeProperty = DependencyProperty.Register("ProcessMode", typeof(ProcessMode), typeof(WizardControl), new PropertyMetadata(ProcessMode.Default, OnProcessModeChanged));
-		/// <summary>
-		/// The sub title property
-		/// </summary>
-		internal readonly static DependencyProperty SubTitleProperty = DependencyProperty.Register(nameof(SubTitle), typeof(string), typeof(WizardControl), new PropertyMetadata("Wizard Sub-Title", OnSubTitleChanged));
+        /// <summary>
+        /// The title property
+        /// </summary>
+        public readonly static DependencyProperty TitleProperty = DependencyProperty.Register("Title", typeof(string), typeof(WizardControl), new PropertyMetadata("Wizard Title", OnTitleChanged));
+        /// <summary>
+        /// The process mode property
+        /// </summary>
+        public readonly static DependencyProperty ProcessModeProperty = DependencyProperty.Register("ProcessMode", typeof(ProcessMode), typeof(WizardControl), new PropertyMetadata(ProcessMode.Default, OnProcessModeChanged));
+        /// <summary>
+        /// The sub title property
+        /// </summary>
+        internal readonly static DependencyProperty SubTitleProperty = DependencyProperty.Register(nameof(SubTitle), typeof(string), typeof(WizardControl), new PropertyMetadata("Wizard Sub-Title", OnSubTitleChanged));
 
-		/// <summary>
-		/// Gets or sets the title.
-		/// </summary>
-		/// <value>The title.</value>
-		public string Title
+        /// <summary>
+        /// Gets or sets the title.
+        /// </summary>
+        /// <value>The title.</value>
+        public string Title
         {
             get { return (string)GetValue(TitleProperty); }
             set { SetValue(TitleProperty, value); }
         }
 
-		/// <summary>
-		/// Gets or sets the sub title.
-		/// </summary>
-		/// <value>The sub title.</value>
-		internal string SubTitle
+        /// <summary>
+        /// Gets or sets the sub title.
+        /// </summary>
+        /// <value>The sub title.</value>
+        internal string SubTitle
         {
             get { return (string)GetValue(SubTitleProperty); }
             set { SetValue(SubTitleProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:TitleChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:TitleChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             WizardControl sh = (WizardControl)d;
             //sh._viewModel.Title = (string)e.NewValue;
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:SubTitleChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnSubTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:SubTitleChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnSubTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             WizardControl sh = (WizardControl)d;
             //sh._viewModel.Title = (string)e.NewValue;
         }
 
-		/// <summary>
-		/// Gets or sets the process mode.
-		/// </summary>
-		/// <value>The process mode.</value>
-		public ProcessMode ProcessMode
+        /// <summary>
+        /// Gets or sets the process mode.
+        /// </summary>
+        /// <value>The process mode.</value>
+        public ProcessMode ProcessMode
         {
             get { return (ProcessMode)GetValue(ProcessModeProperty); }
             set { SetValue(ProcessModeProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:ProcessModeChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnProcessModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:ProcessModeChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnProcessModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             WizardControl sh = (WizardControl)d;
 
-         //   sh._viewModel.ProcessMode = (ProcessMode)e.NewValue;
+            //   sh._viewModel.ProcessMode = (ProcessMode)e.NewValue;
         }
 
 
 
-		#endregion
+        #endregion
 
-		#region Header
+        #region Header
 
-		/// <summary>
-		/// The title text style property
-		/// </summary>
-		public static readonly DependencyProperty TitleTextStyleProperty = DependencyProperty.Register(nameof(TitleTextStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null));
-		/// <summary>
-		/// The sub title text style property
-		/// </summary>
-		public static readonly DependencyProperty SubTitleTextStyleProperty = DependencyProperty.Register(nameof(SubTitleTextStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null));
+        /// <summary>
+        /// The title text style property
+        /// </summary>
+        public static readonly DependencyProperty TitleTextStyleProperty = DependencyProperty.Register(nameof(TitleTextStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null));
+        /// <summary>
+        /// The sub title text style property
+        /// </summary>
+        public static readonly DependencyProperty SubTitleTextStyleProperty = DependencyProperty.Register(nameof(SubTitleTextStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null));
 
-		/// <summary>
-		/// The button style property
-		/// </summary>
-		public readonly static DependencyProperty ButtonStyleProperty = DependencyProperty.Register(nameof(ButtonStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null, OnButtonStyleChanged));
+        /// <summary>
+        /// The button style property
+        /// </summary>
+        public readonly static DependencyProperty ButtonStyleProperty = DependencyProperty.Register(nameof(ButtonStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null, OnButtonStyleChanged));
 
-		/// <summary>
-		/// Gets or sets the title text style.
-		/// </summary>
-		/// <value>The title text style.</value>
-		public Style TitleTextStyle
+        /// <summary>
+        /// Gets or sets the title text style.
+        /// </summary>
+        /// <value>The title text style.</value>
+        public Style TitleTextStyle
         {
             get
             {
@@ -167,11 +168,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets or sets the sub title text style.
-		/// </summary>
-		/// <value>The sub title text style.</value>
-		public Style SubTitleTextStyle
+        /// <summary>
+        /// Gets or sets the sub title text style.
+        /// </summary>
+        /// <value>The sub title text style.</value>
+        public Style SubTitleTextStyle
         {
             get
             {
@@ -183,15 +184,15 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets or sets the button style.
-		/// </summary>
-		/// <value>The button style.</value>
-		public Style ButtonStyle
-		{
-			get { return (Style)GetValue(ButtonStyleProperty); }
-			set { SetValue(ButtonStyleProperty, value); }
-		}
+        /// <summary>
+        /// Gets or sets the button style.
+        /// </summary>
+        /// <value>The button style.</value>
+        public Style ButtonStyle
+        {
+            get { return (Style)GetValue(ButtonStyleProperty); }
+            set { SetValue(ButtonStyleProperty, value); }
+        }
 
         /// <summary>
         /// Handles the <see cref="E:ButtonStyleChanged" /> event.
@@ -205,16 +206,17 @@ namespace DSoft.WizardControl
 
             if (sh.ButtonStyle != null)
             {
-                if (sh._btnNext != null)
-                    sh._btnNext.Style = sh.ButtonStyle;
-                if (sh._btnCancel != null)
-                    sh._btnCancel.Style = sh.ButtonStyle;
-                if (sh._btnFinish != null)
-                    sh._btnFinish.Style = sh.ButtonStyle;
-                if (sh._btnPrevious != null)
-                    sh._btnPrevious.Style = sh.ButtonStyle;
-                if (sh._btnComplete != null)
-                    sh._btnComplete.Style = sh.ButtonStyle;
+                sh.UpdateButtonStyle(WizardButtons.All, sh.ButtonStyle);
+                //if (sh._btnNext != null)
+                //    sh._btnNext.Style = sh.ButtonStyle;
+                //if (sh._btnCancel != null)
+                //    sh._btnCancel.Style = sh.ButtonStyle;
+                //if (sh._btnFinish != null)
+                //    sh._btnFinish.Style = sh.ButtonStyle;
+                //if (sh._btnPrevious != null)
+                //    sh._btnPrevious.Style = sh.ButtonStyle;
+                //if (sh._btnComplete != null)
+                //    sh._btnComplete.Style = sh.ButtonStyle;
             }
         }
 
@@ -225,32 +227,32 @@ namespace DSoft.WizardControl
         /// The selected index property
         /// </summary>
         public static readonly DependencyProperty SelectedIndexProperty = DependencyProperty.Register(nameof(SelectedIndex), typeof(int), typeof(WizardControl), new PropertyMetadata(0, OnInternalSelectedIndexChanged));
-		/// <summary>
-		/// The selected page property
-		/// </summary>
-		public static readonly DependencyProperty SelectedPageProperty = DependencyProperty.Register(nameof(SelectedPage), typeof(IWizardPage), typeof(WizardControl), new PropertyMetadata(null, OnInternalSelectedPageChanged));
-		/// <summary>
-		/// The pages property
-		/// </summary>
-		public static readonly DependencyProperty PagesProperty = DependencyProperty.Register("Pages", typeof(ObservableCollection<IWizardPage>), typeof(WizardControl), new PropertyMetadata(new ObservableCollection<IWizardPage>(), OnPagesChanged));
-		/// <summary>
-		/// The processing page property
-		/// </summary>
-		public static readonly DependencyProperty ProcessingPageProperty = DependencyProperty.Register("ProcessingPage", typeof(IWizardPage), typeof(WizardControl), new PropertyMetadata(null, OnProcessingPageChanged));
-		/// <summary>
-		/// The complete page property
-		/// </summary>
-		public static readonly DependencyProperty CompletePageProperty = DependencyProperty.Register("CompletePage", typeof(IWizardPage), typeof(WizardControl), new PropertyMetadata(null, OnCompletePageChanged));
-		/// <summary>
-		/// The error page property
-		/// </summary>
-		public static readonly DependencyProperty ErrorPageProperty = DependencyProperty.Register("ErrorPage", typeof(IWizardPage), typeof(WizardControl), new PropertyMetadata(null, OnErrorPageChanged));
+        /// <summary>
+        /// The selected page property
+        /// </summary>
+        public static readonly DependencyProperty SelectedPageProperty = DependencyProperty.Register(nameof(SelectedPage), typeof(IWizardPage), typeof(WizardControl), new PropertyMetadata(null, OnInternalSelectedPageChanged));
+        /// <summary>
+        /// The pages property
+        /// </summary>
+        public static readonly DependencyProperty PagesProperty = DependencyProperty.Register("Pages", typeof(ObservableCollection<IWizardPage>), typeof(WizardControl), new PropertyMetadata(new ObservableCollection<IWizardPage>(), OnPagesChanged));
+        /// <summary>
+        /// The processing page property
+        /// </summary>
+        public static readonly DependencyProperty ProcessingPageProperty = DependencyProperty.Register("ProcessingPage", typeof(IWizardPage), typeof(WizardControl), new PropertyMetadata(null, OnProcessingPageChanged));
+        /// <summary>
+        /// The complete page property
+        /// </summary>
+        public static readonly DependencyProperty CompletePageProperty = DependencyProperty.Register("CompletePage", typeof(IWizardPage), typeof(WizardControl), new PropertyMetadata(null, OnCompletePageChanged));
+        /// <summary>
+        /// The error page property
+        /// </summary>
+        public static readonly DependencyProperty ErrorPageProperty = DependencyProperty.Register("ErrorPage", typeof(IWizardPage), typeof(WizardControl), new PropertyMetadata(null, OnErrorPageChanged));
 
-		/// <summary>
-		/// Gets or sets the index of the selected.
-		/// </summary>
-		/// <value>The index of the selected.</value>
-		public int SelectedIndex
+        /// <summary>
+        /// Gets or sets the index of the selected.
+        /// </summary>
+        /// <value>The index of the selected.</value>
+        public int SelectedIndex
         {
             get
             {
@@ -262,23 +264,23 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:InternalSelectedIndexChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnInternalSelectedIndexChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:InternalSelectedIndexChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnInternalSelectedIndexChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sh = (WizardControl)d;
 
 
         }
 
-		/// <summary>
-		/// Gets the last index of the active page.
-		/// </summary>
-		/// <value>The last index of the active page.</value>
-		private int LastActivePageIndex
+        /// <summary>
+        /// Gets the last index of the active page.
+        /// </summary>
+        /// <value>The last index of the active page.</value>
+        private int LastActivePageIndex
         {
             get
             {
@@ -286,11 +288,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets the active pages.
-		/// </summary>
-		/// <value>The active pages.</value>
-		public Dictionary<int, IWizardPage> ActivePages
+        /// <summary>
+        /// Gets the active pages.
+        /// </summary>
+        /// <value>The active pages.</value>
+        public Dictionary<int, IWizardPage> ActivePages
         {
             get
             {
@@ -312,45 +314,45 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets or sets the pages.
-		/// </summary>
-		/// <value>The pages.</value>
-		public ObservableCollection<IWizardPage> Pages
+        /// <summary>
+        /// Gets or sets the pages.
+        /// </summary>
+        /// <value>The pages.</value>
+        public ObservableCollection<IWizardPage> Pages
         {
             get { return (ObservableCollection<IWizardPage>)GetValue(PagesProperty); }
             set { SetValue(PagesProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:PagesChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnPagesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:PagesChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnPagesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sh = (WizardControl)d;
 
             sh.SetPage(0);
 
-		}
+        }
 
-		/// <summary>
-		/// Gets or sets the processing page.
-		/// </summary>
-		/// <value>The processing page.</value>
-		public IWizardPage ProcessingPage
+        /// <summary>
+        /// Gets or sets the processing page.
+        /// </summary>
+        /// <value>The processing page.</value>
+        public IWizardPage ProcessingPage
         {
             get { return (IWizardPage)GetValue(ProcessingPageProperty); }
             set { SetValue(ProcessingPageProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:ProcessingPageChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnProcessingPageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:ProcessingPageChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnProcessingPageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sh = (WizardControl)d;
 
@@ -360,48 +362,48 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets or sets the complete page.
-		/// </summary>
-		/// <value>The complete page.</value>
-		public IWizardPage CompletePage
+        /// <summary>
+        /// Gets or sets the complete page.
+        /// </summary>
+        /// <value>The complete page.</value>
+        public IWizardPage CompletePage
         {
             get { return (IWizardPage)GetValue(CompletePageProperty); }
             set { SetValue(CompletePageProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:CompletePageChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnCompletePageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:CompletePageChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnCompletePageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sh = (WizardControl)d;
 
-            if (e.NewValue != null && sh.CompletePage  != e.NewValue)
+            if (e.NewValue != null && sh.CompletePage != e.NewValue)
             {
                 sh.ReplacePage(sh.CompletePage, (IWizardPage)e.NewValue);
             }
 
         }
 
-		/// <summary>
-		/// Gets or sets the error page.
-		/// </summary>
-		/// <value>The error page.</value>
-		public IWizardPage ErrorPage
+        /// <summary>
+        /// Gets or sets the error page.
+        /// </summary>
+        /// <value>The error page.</value>
+        public IWizardPage ErrorPage
         {
             get { return (IWizardPage)GetValue(ErrorPageProperty); }
             set { SetValue(ErrorPageProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:ErrorPageChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnErrorPageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:ErrorPageChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnErrorPageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sh = (WizardControl)d;
 
@@ -412,153 +414,153 @@ namespace DSoft.WizardControl
 
         }
 
-		/// <summary>
-		/// Gets or sets the selected page.
-		/// </summary>
-		/// <value>The selected page.</value>
-		public IWizardPage SelectedPage
+        /// <summary>
+        /// Gets or sets the selected page.
+        /// </summary>
+        /// <value>The selected page.</value>
+        public IWizardPage SelectedPage
         {
             get { return (IWizardPage)GetValue(SelectedPageProperty); }
             set { SetValue(SelectedPageProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:InternalSelectedPageChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnInternalSelectedPageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:InternalSelectedPageChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnInternalSelectedPageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sh = (WizardControl)d;
 
 
         }
-		#endregion
+        #endregion
 
-		#region Button Titles
+        #region Button Titles
 
-		/// <summary>
-		/// The process button title property
-		/// </summary>
-		public readonly static DependencyProperty ProcessButtonTitleProperty = DependencyProperty.Register("ProcessButtonTitle", typeof(string), typeof(WizardControl), new PropertyMetadata("Process", OnProcessButtonTitleChanged));
-		/// <summary>
-		/// The close button title property
-		/// </summary>
-		public readonly static DependencyProperty CloseButtonTitleProperty = DependencyProperty.Register("CloseButtonTitle", typeof(string), typeof(WizardControl), new PropertyMetadata("Close", OnCloseButtonTitleChanged));
-		/// <summary>
-		/// The cancel button title property
-		/// </summary>
-		public readonly static DependencyProperty CancelButtonTitleProperty = DependencyProperty.Register("CancelButtonTitle", typeof(string), typeof(WizardControl), new PropertyMetadata("Cancel", OnCancelButtonTitleChanged));
-		/// <summary>
-		/// The next button title property
-		/// </summary>
-		public readonly static DependencyProperty NextButtonTitleProperty = DependencyProperty.Register("NextButtonTitle", typeof(string), typeof(WizardControl), new PropertyMetadata("Next", OnNextButtonTitleChanged));
-		/// <summary>
-		/// The previous button title property
-		/// </summary>
-		public readonly static DependencyProperty PreviousButtonTitleProperty = DependencyProperty.Register("PreviousButtonTitle", typeof(string), typeof(WizardControl), new PropertyMetadata("Previous", OnPreviousButtonTitleChanged));
+        /// <summary>
+        /// The process button title property
+        /// </summary>
+        public readonly static DependencyProperty ProcessButtonTitleProperty = DependencyProperty.Register("ProcessButtonTitle", typeof(string), typeof(WizardControl), new PropertyMetadata("Process", OnProcessButtonTitleChanged));
+        /// <summary>
+        /// The close button title property
+        /// </summary>
+        public readonly static DependencyProperty CloseButtonTitleProperty = DependencyProperty.Register("CloseButtonTitle", typeof(string), typeof(WizardControl), new PropertyMetadata("Close", OnCloseButtonTitleChanged));
+        /// <summary>
+        /// The cancel button title property
+        /// </summary>
+        public readonly static DependencyProperty CancelButtonTitleProperty = DependencyProperty.Register("CancelButtonTitle", typeof(string), typeof(WizardControl), new PropertyMetadata("Cancel", OnCancelButtonTitleChanged));
+        /// <summary>
+        /// The next button title property
+        /// </summary>
+        public readonly static DependencyProperty NextButtonTitleProperty = DependencyProperty.Register("NextButtonTitle", typeof(string), typeof(WizardControl), new PropertyMetadata("Next", OnNextButtonTitleChanged));
+        /// <summary>
+        /// The previous button title property
+        /// </summary>
+        public readonly static DependencyProperty PreviousButtonTitleProperty = DependencyProperty.Register("PreviousButtonTitle", typeof(string), typeof(WizardControl), new PropertyMetadata("Previous", OnPreviousButtonTitleChanged));
 
 
-		/// <summary>
-		/// Gets or sets the process button title.
-		/// </summary>
-		/// <value>The process button title.</value>
-		public string ProcessButtonTitle
+        /// <summary>
+        /// Gets or sets the process button title.
+        /// </summary>
+        /// <value>The process button title.</value>
+        public string ProcessButtonTitle
         {
             get { return (string)GetValue(ProcessButtonTitleProperty); }
             set { SetValue(ProcessButtonTitleProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:ProcessButtonTitleChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnProcessButtonTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:ProcessButtonTitleChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnProcessButtonTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sh = (WizardControl)d;
             //sh._viewModel.ProcessButtonTitle = (string)e.NewValue;
         }
 
-		/// <summary>
-		/// Gets or sets the close button title.
-		/// </summary>
-		/// <value>The close button title.</value>
-		public string CloseButtonTitle
+        /// <summary>
+        /// Gets or sets the close button title.
+        /// </summary>
+        /// <value>The close button title.</value>
+        public string CloseButtonTitle
         {
             get => (string)GetValue(CloseButtonTitleProperty);
             set => SetValue(CloseButtonTitleProperty, value);
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:CloseButtonTitleChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnCloseButtonTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:CloseButtonTitleChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnCloseButtonTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sh = (WizardControl)d;
             //sh._viewModel.CloseButtonTitle = (string)e.NewValue;
         }
 
-		/// <summary>
-		/// Gets or sets the cancel button title.
-		/// </summary>
-		/// <value>The cancel button title.</value>
-		public string CancelButtonTitle
+        /// <summary>
+        /// Gets or sets the cancel button title.
+        /// </summary>
+        /// <value>The cancel button title.</value>
+        public string CancelButtonTitle
         {
             get => (string)GetValue(CancelButtonTitleProperty);
             set => SetValue(CancelButtonTitleProperty, value);
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:CancelButtonTitleChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnCancelButtonTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:CancelButtonTitleChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnCancelButtonTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sh = (WizardControl)d;
             //sh._viewModel.CancelButtonTitle = (string)e.NewValue;
         }
 
-		/// <summary>
-		/// Gets or sets the next button title.
-		/// </summary>
-		/// <value>The next button title.</value>
-		public string NextButtonTitle
+        /// <summary>
+        /// Gets or sets the next button title.
+        /// </summary>
+        /// <value>The next button title.</value>
+        public string NextButtonTitle
         {
             get { return (string)GetValue(NextButtonTitleProperty); }
             set { SetValue(NextButtonTitleProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:NextButtonTitleChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnNextButtonTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:NextButtonTitleChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnNextButtonTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sh = (WizardControl)d;
             //sh._viewModel.NextButtonTitle = (string)e.NewValue;
         }
 
-		/// <summary>
-		/// Gets or sets the previous button title.
-		/// </summary>
-		/// <value>The previous button title.</value>
-		public string PreviousButtonTitle
+        /// <summary>
+        /// Gets or sets the previous button title.
+        /// </summary>
+        /// <value>The previous button title.</value>
+        public string PreviousButtonTitle
         {
             get { return (string)GetValue(PreviousButtonTitleProperty); }
             set { SetValue(PreviousButtonTitleProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:PreviousButtonTitleChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnPreviousButtonTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:PreviousButtonTitleChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnPreviousButtonTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sh = (WizardControl)d;
             //sh._viewModel.PreviousButtonTitle = (string)e.NewValue;
@@ -572,55 +574,101 @@ namespace DSoft.WizardControl
         internal static readonly DependencyProperty ProcessEnabledProperty = DependencyProperty.Register(nameof(ProcessEnabled), typeof(bool), typeof(WizardControl), new PropertyMetadata(null));
         internal static readonly DependencyProperty CancelEnabledProperty = DependencyProperty.Register(nameof(CancelEnabled), typeof(bool), typeof(WizardControl), new PropertyMetadata(null));
         internal static readonly DependencyProperty CompleteEnabledProperty = DependencyProperty.Register(nameof(CompleteEnabled), typeof(bool), typeof(WizardControl), new PropertyMetadata(null));
-		/// <summary>
-		/// Is previous button enabled
-		/// </summary>
-		/// <value><c>true</c> if [previous enabled]; otherwise, <c>false</c>.</value>
-		internal bool PreviousEnabled
+        /// <summary>
+        /// Is previous button enabled
+        /// </summary>
+        /// <value><c>true</c> if [previous enabled]; otherwise, <c>false</c>.</value>
+        internal bool PreviousEnabled
         {
             get { return (bool)GetValue(PreviousEnabledProperty); }
             set { SetValue(PreviousEnabledProperty, value); }
         }
 
-		/// <summary>
-		/// Is next button enabled
-		/// </summary>
-		/// <value><c>true</c> if [next enabled]; otherwise, <c>false</c>.</value>
-		internal bool NextEnabled
+        /// <summary>
+        /// Is next button enabled
+        /// </summary>
+        /// <value><c>true</c> if [next enabled]; otherwise, <c>false</c>.</value>
+        internal bool NextEnabled
         {
             get { return (bool)GetValue(NextEnabledProperty); }
             set { SetValue(NextEnabledProperty, value); }
         }
 
-		/// <summary>
-		/// Is finish button enabled
-		/// </summary>
-		/// <value><c>true</c> if [process enabled]; otherwise, <c>false</c>.</value>
-		internal bool ProcessEnabled
+        /// <summary>
+        /// Is finish button enabled
+        /// </summary>
+        /// <value><c>true</c> if [process enabled]; otherwise, <c>false</c>.</value>
+        internal bool ProcessEnabled
         {
             get { return (bool)GetValue(ProcessEnabledProperty); }
             set { SetValue(ProcessEnabledProperty, value); }
         }
 
-		/// <summary>
-		/// Is previous button enabled
-		/// </summary>
-		/// <value><c>true</c> if [cancel enabled]; otherwise, <c>false</c>.</value>
-		internal bool CancelEnabled
+        /// <summary>
+        /// Is previous button enabled
+        /// </summary>
+        /// <value><c>true</c> if [cancel enabled]; otherwise, <c>false</c>.</value>
+        internal bool CancelEnabled
         {
             get { return (bool)GetValue(CancelEnabledProperty); }
             set { SetValue(CancelEnabledProperty, value); }
         }
 
-		/// <summary>
-		/// Gets or sets a value indicating whether [complete enabled].
-		/// </summary>
-		/// <value><c>true</c> if [complete enabled]; otherwise, <c>false</c>.</value>
-		internal bool CompleteEnabled
+        /// <summary>
+        /// Gets or sets a value indicating whether [complete enabled].
+        /// </summary>
+        /// <value><c>true</c> if [complete enabled]; otherwise, <c>false</c>.</value>
+        internal bool CompleteEnabled
         {
             get { return (bool)GetValue(CompleteEnabledProperty); }
             set { SetValue(CompleteEnabledProperty, value); }
         }
+
+        #endregion
+
+        #region Button Styles
+        internal static readonly DependencyProperty CompleteButtonStyleProperty = DependencyProperty.Register(nameof(CompleteButtonStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null));
+        internal static readonly DependencyProperty CancelButtonStyleProperty = DependencyProperty.Register(nameof(CancelButtonStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null));
+        internal static readonly DependencyProperty ProcessButtonStyleProperty = DependencyProperty.Register(nameof(ProcessButtonStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null));
+        //internal static readonly DependencyProperty ButtonStackStyleProperty = DependencyProperty.Register(nameof(ButtonStackStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null));
+        internal static readonly DependencyProperty NextButtonStyleProperty = DependencyProperty.Register(nameof(NextButtonStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null));
+        internal static readonly DependencyProperty PreviousButtonStyleProperty = DependencyProperty.Register(nameof(PreviousButtonStyle), typeof(Style), typeof(WizardControl), new PropertyMetadata(null));
+
+        internal Style CompleteButtonStyle
+        {
+            get => (Style)this.GetValue(CompleteButtonStyleProperty);
+            set => this.SetValue(CompleteButtonStyleProperty, value);
+        }
+
+        internal Style CancelButtonStyle
+        {
+            get => (Style)this.GetValue(CancelButtonStyleProperty);
+            set => this.SetValue(CancelButtonStyleProperty, value);
+        }
+
+        internal Style ProcessButtonStyle
+        {
+            get => (Style)this.GetValue(ProcessButtonStyleProperty);
+            set => this.SetValue(ProcessButtonStyleProperty, value);
+        }
+
+        internal Style NextButtonStyle
+        {
+            get => (Style)this.GetValue(NextButtonStyleProperty);
+            set => this.SetValue(NextButtonStyleProperty, value);
+        }
+
+        internal Style PreviousButtonStyle
+        {
+            get => (Style)this.GetValue(PreviousButtonStyleProperty);
+            set => this.SetValue(PreviousButtonStyleProperty, value);
+        }
+
+        //internal Style ButtonStackStyle
+        //{
+        //    get => (Style)this.GetValue(ButtonStackStyleProperty);
+        //    set => this.SetValue(ButtonStackStyleProperty, value);
+        //}
 
         #endregion
 
@@ -633,11 +681,11 @@ namespace DSoft.WizardControl
         internal static readonly DependencyProperty NextButtonVisibilityProperty = DependencyProperty.Register(nameof(NextButtonVisibility), typeof(Visibility), typeof(WizardControl), new PropertyMetadata(null));
         internal static readonly DependencyProperty PreviousButtonVisibilityProperty = DependencyProperty.Register(nameof(PreviousButtonVisibility), typeof(Visibility), typeof(WizardControl), new PropertyMetadata(null));
 
-		/// <summary>
-		/// Gets or sets the complete button visibility.
-		/// </summary>
-		/// <value>The complete button visibility.</value>
-		internal Visibility CompleteButtonVisibility
+        /// <summary>
+        /// Gets or sets the complete button visibility.
+        /// </summary>
+        /// <value>The complete button visibility.</value>
+        internal Visibility CompleteButtonVisibility
         {
             get
             {
@@ -650,11 +698,11 @@ namespace DSoft.WizardControl
 
         }
 
-		/// <summary>
-		/// Gets or sets the cancel button visibility.
-		/// </summary>
-		/// <value>The cancel button visibility.</value>
-		internal Visibility CancelButtonVisibility
+        /// <summary>
+        /// Gets or sets the cancel button visibility.
+        /// </summary>
+        /// <value>The cancel button visibility.</value>
+        internal Visibility CancelButtonVisibility
         {
             get
             {
@@ -667,11 +715,11 @@ namespace DSoft.WizardControl
 
         }
 
-		/// <summary>
-		/// Gets or sets the process button visibility.
-		/// </summary>
-		/// <value>The process button visibility.</value>
-		internal Visibility ProcessButtonVisibility
+        /// <summary>
+        /// Gets or sets the process button visibility.
+        /// </summary>
+        /// <value>The process button visibility.</value>
+        internal Visibility ProcessButtonVisibility
         {
             get
             {
@@ -684,11 +732,11 @@ namespace DSoft.WizardControl
 
         }
 
-		/// <summary>
-		/// Gets or sets the button stack visibility.
-		/// </summary>
-		/// <value>The button stack visibility.</value>
-		internal Visibility ButtonStackVisibility
+        /// <summary>
+        /// Gets or sets the button stack visibility.
+        /// </summary>
+        /// <value>The button stack visibility.</value>
+        internal Visibility ButtonStackVisibility
         {
             get
             {
@@ -700,11 +748,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets or sets the next button visibility.
-		/// </summary>
-		/// <value>The next button visibility.</value>
-		internal Visibility NextButtonVisibility
+        /// <summary>
+        /// Gets or sets the next button visibility.
+        /// </summary>
+        /// <value>The next button visibility.</value>
+        internal Visibility NextButtonVisibility
         {
             get
             {
@@ -717,11 +765,11 @@ namespace DSoft.WizardControl
 
         }
 
-		/// <summary>
-		/// Gets or sets the previous button visibility.
-		/// </summary>
-		/// <value>The previous button visibility.</value>
-		internal Visibility PreviousButtonVisibility
+        /// <summary>
+        /// Gets or sets the previous button visibility.
+        /// </summary>
+        /// <value>The previous button visibility.</value>
+        internal Visibility PreviousButtonVisibility
         {
             get
             {
@@ -734,82 +782,82 @@ namespace DSoft.WizardControl
 
         }
 
-		#endregion
+        #endregion
 
 
-		#region Functions
+        #region Functions
 
-		/// <summary>
-		/// The process function property
-		/// </summary>
-		public static readonly DependencyProperty ProcessFunctionProperty = DependencyProperty.Register("ProcessFunction", typeof(Func<Task<WizardProcessResult>>), typeof(WizardControl), new PropertyMetadata(null, OnProcessFunctionChanged));
-		/// <summary>
-		/// The close function property
-		/// </summary>
-		public static readonly DependencyProperty CloseFunctionProperty = DependencyProperty.Register("CloseFunction", typeof(Action), typeof(WizardControl), new PropertyMetadata(null, OnCloseFunctionChanged));
-		/// <summary>
-		/// The cancel function property
-		/// </summary>
-		public static readonly DependencyProperty CancelFunctionProperty = DependencyProperty.Register("CancelFunction", typeof(Action), typeof(WizardControl), new PropertyMetadata(null, OnCancelFunctionChanged));
+        /// <summary>
+        /// The process function property
+        /// </summary>
+        public static readonly DependencyProperty ProcessFunctionProperty = DependencyProperty.Register("ProcessFunction", typeof(Func<Task<WizardProcessResult>>), typeof(WizardControl), new PropertyMetadata(null, OnProcessFunctionChanged));
+        /// <summary>
+        /// The close function property
+        /// </summary>
+        public static readonly DependencyProperty CloseFunctionProperty = DependencyProperty.Register("CloseFunction", typeof(Action), typeof(WizardControl), new PropertyMetadata(null, OnCloseFunctionChanged));
+        /// <summary>
+        /// The cancel function property
+        /// </summary>
+        public static readonly DependencyProperty CancelFunctionProperty = DependencyProperty.Register("CancelFunction", typeof(Action), typeof(WizardControl), new PropertyMetadata(null, OnCancelFunctionChanged));
 
-		/// <summary>
-		/// Gets or sets the process function.
-		/// </summary>
-		/// <value>The process function.</value>
-		public Func<Task<WizardProcessResult>> ProcessFunction
+        /// <summary>
+        /// Gets or sets the process function.
+        /// </summary>
+        /// <value>The process function.</value>
+        public Func<Task<WizardProcessResult>> ProcessFunction
         {
             get { return (Func<Task<WizardProcessResult>>)GetValue(ProcessFunctionProperty); }
             set { SetValue(ProcessFunctionProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:ProcessFunctionChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnProcessFunctionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:ProcessFunctionChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnProcessFunctionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             WizardControl sh = (WizardControl)d;
             //sh._viewModel.ProcessFunction = (Func<Task<WizardProcessResult>>)e.NewValue;
         }
 
-		/// <summary>
-		/// Gets or sets the close function.
-		/// </summary>
-		/// <value>The close function.</value>
-		public Action CloseFunction
+        /// <summary>
+        /// Gets or sets the close function.
+        /// </summary>
+        /// <value>The close function.</value>
+        public Action CloseFunction
         {
             get { return (Action)GetValue(CloseFunctionProperty); }
             set { SetValue(CloseFunctionProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:CloseFunctionChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnCloseFunctionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:CloseFunctionChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnCloseFunctionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             WizardControl sh = (WizardControl)d;
             //sh._viewModel.CloseFunction = (Action)e.NewValue;
         }
 
-		/// <summary>
-		/// Gets or sets the cancel function.
-		/// </summary>
-		/// <value>The cancel function.</value>
-		public Action CancelFunction
+        /// <summary>
+        /// Gets or sets the cancel function.
+        /// </summary>
+        /// <value>The cancel function.</value>
+        public Action CancelFunction
         {
             get { return (Action)GetValue(CancelFunctionProperty); }
             set { SetValue(CancelFunctionProperty, value); }
         }
 
-		/// <summary>
-		/// Handles the <see cref="E:CancelFunctionChanged" /> event.
-		/// </summary>
-		/// <param name="d">The d.</param>
-		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
-		private static void OnCancelFunctionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Handles the <see cref="E:CancelFunctionChanged" /> event.
+        /// </summary>
+        /// <param name="d">The d.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
+        private static void OnCancelFunctionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             WizardControl sh = (WizardControl)d;
             //sh._viewModel.CancelFunction = (Action)e.NewValue;
@@ -828,11 +876,11 @@ namespace DSoft.WizardControl
 
 
 
-		/// <summary>
-		/// Gets the previous command.
-		/// </summary>
-		/// <value>The previous command.</value>
-		internal ICommand PreviousCommand
+        /// <summary>
+        /// Gets the previous command.
+        /// </summary>
+        /// <value>The previous command.</value>
+        internal ICommand PreviousCommand
         {
             get
             {
@@ -844,11 +892,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets the next command.
-		/// </summary>
-		/// <value>The next command.</value>
-		internal ICommand NextCommand
+        /// <summary>
+        /// Gets the next command.
+        /// </summary>
+        /// <value>The next command.</value>
+        internal ICommand NextCommand
         {
             get
             {
@@ -860,11 +908,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets or sets the process button command.
-		/// </summary>
-		/// <value>The process button command.</value>
-		internal ICommand ProcessButtonCommand
+        /// <summary>
+        /// Gets or sets the process button command.
+        /// </summary>
+        /// <value>The process button command.</value>
+        internal ICommand ProcessButtonCommand
         {
             get
             {
@@ -876,11 +924,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Command to be called when the wizard completes.  Should be set in the View to be called by the view model
-		/// </summary>
-		/// <value>The complete command.</value>
-		internal ICommand CompleteCommand
+        /// <summary>
+        /// Command to be called when the wizard completes.  Should be set in the View to be called by the view model
+        /// </summary>
+        /// <value>The complete command.</value>
+        internal ICommand CompleteCommand
         {
             get
             {
@@ -892,11 +940,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets or sets the cancel command.
-		/// </summary>
-		/// <value>The cancel command.</value>
-		internal ICommand CancelCommand
+        /// <summary>
+        /// Gets or sets the cancel command.
+        /// </summary>
+        /// <value>The cancel command.</value>
+        internal ICommand CancelCommand
         {
             get
             {
@@ -908,21 +956,21 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets the available pages.
-		/// </summary>
-		/// <value>The available pages.</value>
-		public List<IWizardPage> AvailablePages => Pages?.ToList();
+        /// <summary>
+        /// Gets the available pages.
+        /// </summary>
+        /// <value>The available pages.</value>
+        public List<IWizardPage> AvailablePages => Pages?.ToList();
 
-		#endregion
+        #endregion
 
-		#region Internal Enabled
+        #region Internal Enabled
 
-		/// <summary>
-		/// Is previous button enabled
-		/// </summary>
-		/// <value><c>true</c> if this instance is previous enabled; otherwise, <c>false</c>.</value>
-		private bool IsPreviousEnabled
+        /// <summary>
+        /// Is previous button enabled
+        /// </summary>
+        /// <value><c>true</c> if this instance is previous enabled; otherwise, <c>false</c>.</value>
+        private bool IsPreviousEnabled
         {
             get
             {
@@ -951,11 +999,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Is next button enabled
-		/// </summary>
-		/// <value><c>true</c> if this instance is next enabled; otherwise, <c>false</c>.</value>
-		private bool IsNextEnabled
+        /// <summary>
+        /// Is next button enabled
+        /// </summary>
+        /// <value><c>true</c> if this instance is next enabled; otherwise, <c>false</c>.</value>
+        private bool IsNextEnabled
         {
             get
             {
@@ -980,11 +1028,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Is finish button enabled
-		/// </summary>
-		/// <value><c>true</c> if this instance is process enabled; otherwise, <c>false</c>.</value>
-		private bool IsProcessEnabled
+        /// <summary>
+        /// Is finish button enabled
+        /// </summary>
+        /// <value><c>true</c> if this instance is process enabled; otherwise, <c>false</c>.</value>
+        private bool IsProcessEnabled
         {
             get
             {
@@ -1010,11 +1058,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Is previous button enabled
-		/// </summary>
-		/// <value><c>true</c> if this instance is cancel enabled; otherwise, <c>false</c>.</value>
-		private bool IsCancelEnabled
+        /// <summary>
+        /// Is previous button enabled
+        /// </summary>
+        /// <value><c>true</c> if this instance is cancel enabled; otherwise, <c>false</c>.</value>
+        private bool IsCancelEnabled
         {
             get
             {
@@ -1039,11 +1087,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets a value indicating whether this instance is complete enabled.
-		/// </summary>
-		/// <value><c>true</c> if this instance is complete enabled; otherwise, <c>false</c>.</value>
-		private bool IsCompleteEnabled
+        /// <summary>
+        /// Gets a value indicating whether this instance is complete enabled.
+        /// </summary>
+        /// <value><c>true</c> if this instance is complete enabled; otherwise, <c>false</c>.</value>
+        private bool IsCompleteEnabled
         {
             get
             {
@@ -1070,23 +1118,23 @@ namespace DSoft.WizardControl
         }
 
 
-		#endregion
+        #endregion
 
 
-		#region Visibility
+        #region Visibility
 
 
-		/// <summary>
-		/// Gets the is complete button visibility.
-		/// </summary>
-		/// <value>The is complete button visibility.</value>
-		internal Visibility IsCompleteButtonVisibility
+        /// <summary>
+        /// Gets the is complete button visibility.
+        /// </summary>
+        /// <value>The is complete button visibility.</value>
+        internal Visibility IsCompleteButtonVisibility
         {
             get
             {
 
-                if (_buttonVisibility.ContainsKey(WizardButtons.Complete))
-                    return _buttonVisibility[WizardButtons.Complete];
+                if (_buttonState.ContainsKey(WizardButtons.Complete))
+                    return _buttonState[WizardButtons.Complete].GUIVisibility;
 
                 if (!CompleteEnabled)
                     return Visibility.Collapsed;
@@ -1096,16 +1144,16 @@ namespace DSoft.WizardControl
 
         }
 
-		/// <summary>
-		/// Gets the is cancel button visibility.
-		/// </summary>
-		/// <value>The is cancel button visibility.</value>
-		internal Visibility IsCancelButtonVisibility
+        /// <summary>
+        /// Gets the is cancel button visibility.
+        /// </summary>
+        /// <value>The is cancel button visibility.</value>
+        internal Visibility IsCancelButtonVisibility
         {
             get
             {
-                if (_buttonVisibility.ContainsKey(WizardButtons.Cancel))
-                    return _buttonVisibility[WizardButtons.Cancel];
+                if (_buttonState.ContainsKey(WizardButtons.Cancel))
+                    return _buttonState[WizardButtons.Cancel].GUIVisibility;
 
                 if (!CancelEnabled)
                     return Visibility.Collapsed;
@@ -1115,35 +1163,35 @@ namespace DSoft.WizardControl
 
         }
 
-		/// <summary>
-		/// Gets the is process button visibility.
-		/// </summary>
-		/// <value>The is process button visibility.</value>
-		internal Visibility IsProcessButtonVisibility
+        /// <summary>
+        /// Gets the is process button visibility.
+        /// </summary>
+        /// <value>The is process button visibility.</value>
+        internal Visibility IsProcessButtonVisibility
         {
             get
             {
                 if (!ProcessEnabled)
                     return Visibility.Collapsed;
 
-                if (_buttonVisibility.ContainsKey(WizardButtons.Process))
-                    return _buttonVisibility[WizardButtons.Process];
+                if (_buttonState.ContainsKey(WizardButtons.Process))
+                    return _buttonState[WizardButtons.Process].GUIVisibility;
 
                 return Visibility.Visible;
             }
 
         }
 
-		/// <summary>
-		/// Gets the is button stack visibility.
-		/// </summary>
-		/// <value>The is button stack visibility.</value>
-		internal Visibility IsButtonStackVisibility
+        /// <summary>
+        /// Gets the is button stack visibility.
+        /// </summary>
+        /// <value>The is button stack visibility.</value>
+        internal Visibility IsButtonStackVisibility
         {
             get
             {
-                if (_buttonVisibility.ContainsKey(WizardButtons.All))
-                    return _buttonVisibility[WizardButtons.All];
+                if (_buttonState.ContainsKey(WizardButtons.All))
+                    return _buttonState[WizardButtons.All].GUIVisibility;
 
                 if (SelectedPage != null)
                 {
@@ -1154,38 +1202,38 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Gets the is next button visibility.
-		/// </summary>
-		/// <value>The is next button visibility.</value>
-		internal Visibility IsNextButtonVisibility
+        /// <summary>
+        /// Gets the is next button visibility.
+        /// </summary>
+        /// <value>The is next button visibility.</value>
+        internal Visibility IsNextButtonVisibility
         {
             get
             {
                 if (!NextEnabled)
                     return Visibility.Collapsed;
 
-                if (_buttonVisibility.ContainsKey(WizardButtons.Next))
-                    return _buttonVisibility[WizardButtons.Next];
+                if (_buttonState.ContainsKey(WizardButtons.Next))
+                    return _buttonState[WizardButtons.Next].GUIVisibility;
 
                 return Visibility.Visible;
             }
 
         }
 
-		/// <summary>
-		/// Gets the is previous button visibility.
-		/// </summary>
-		/// <value>The is previous button visibility.</value>
-		internal Visibility IsPreviousButtonVisibility
+        /// <summary>
+        /// Gets the is previous button visibility.
+        /// </summary>
+        /// <value>The is previous button visibility.</value>
+        internal Visibility IsPreviousButtonVisibility
         {
             get
             {
                 if (!PreviousEnabled)
                     return Visibility.Collapsed;
 
-                if (_buttonVisibility.ContainsKey(WizardButtons.Previous))
-                    return _buttonVisibility[WizardButtons.Previous];
+                if (_buttonState.ContainsKey(WizardButtons.Previous))
+                    return _buttonState[WizardButtons.Previous].GUIVisibility;
 
                 return Visibility.Visible;
 
@@ -1193,15 +1241,15 @@ namespace DSoft.WizardControl
 
         }
 
-		#endregion
+        #endregion
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="WizardControl" /> class.
-		/// </summary>
-		public WizardControl()
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WizardControl" /> class.
+        /// </summary>
+        public WizardControl()
         {
             this.DefaultStyleKey = typeof(WizardControl);
-		}
+        }
 
         static WizardControl()
         {
@@ -1236,8 +1284,8 @@ namespace DSoft.WizardControl
             _btnComplete = GetTemplateChild("PART_BTN_COMPLETE") as Button;
             _btnFinish = GetTemplateChild("PART_BTN_FINISH") as Button;
 
-            
-			PreviousCommand = new DelegateCommand(() =>
+
+            PreviousCommand = new DelegateCommand(() =>
             {
                 Navigate(NavigationDirection.Backwards);
             });
@@ -1260,7 +1308,7 @@ namespace DSoft.WizardControl
 #endif
 
                     {
-            try
+                        try
                         {
                             SetPage(Pages.IndexOf(ProcessingPage));
 
@@ -1339,61 +1387,52 @@ namespace DSoft.WizardControl
 
             if (ButtonStyle != null)
             {
-				if (_btnNext != null)
-					_btnNext.Style = ButtonStyle;
-				if (_btnCancel != null)
-					_btnCancel.Style = ButtonStyle;
-				if (_btnFinish != null)
-					_btnFinish.Style = ButtonStyle;
-				if (_btnPrevious != null)
-					_btnPrevious.Style = ButtonStyle;
-				if (_btnComplete != null)
-					_btnComplete.Style = ButtonStyle;
-			}
+                UpdateButtonStyle(WizardButtons.All, ButtonStyle);
+            }
 
             SetPage(0);
         }
 
 
-#region IWizard Elements
+        #region IWizard Elements
 
-		/// <summary>
-		/// Starts the processing stage.
-		/// </summary>
-		public void StartProcessingStage()
+        /// <summary>
+        /// Starts the processing stage.
+        /// </summary>
+        public void StartProcessingStage()
         {
             _currentStage = WizardStage.Working;
         }
 
-		/// <summary>
-		/// Starts the completion stage.
-		/// </summary>
-		public void StartCompletionStage()
+        /// <summary>
+        /// Starts the completion stage.
+        /// </summary>
+        public void StartCompletionStage()
         {
             _currentStage = WizardStage.Complete;
         }
 
-		/// <summary>
-		/// Starts the setup stage.
-		/// </summary>
-		public void StartSetupStage()
+        /// <summary>
+        /// Starts the setup stage.
+        /// </summary>
+        public void StartSetupStage()
         {
             _currentStage = WizardStage.Setup;
         }
 
-		/// <summary>
-		/// Starts the error stage.
-		/// </summary>
-		public void StartErrorStage()
+        /// <summary>
+        /// Starts the error stage.
+        /// </summary>
+        public void StartErrorStage()
         {
             _currentStage = WizardStage.Error;
         }
 
-		/// <summary>
-		/// Navigates the specified direction.
-		/// </summary>
-		/// <param name="direction">The direction.</param>
-		public async void Navigate(NavigationDirection direction)
+        /// <summary>
+        /// Navigates the specified direction.
+        /// </summary>
+        /// <param name="direction">The direction.</param>
+        public async void Navigate(NavigationDirection direction)
         {
             switch (direction)
             {
@@ -1426,11 +1465,11 @@ namespace DSoft.WizardControl
             }
         }
 
-		/// <summary>
-		/// Sets the page.
-		/// </summary>
-		/// <param name="newIndex">The new index.</param>
-		internal void SetPage(int newIndex)
+        /// <summary>
+        /// Sets the page.
+        /// </summary>
+        /// <param name="newIndex">The new index.</param>
+        internal void SetPage(int newIndex)
         {
             if (Pages == null || Pages.Count == 0)
             {
@@ -1458,7 +1497,7 @@ namespace DSoft.WizardControl
             this.SelectedIndex = newIndex;
             SelectedPage = Pages[SelectedIndex];
 
-            _buttonVisibility.Clear();
+            _buttonState.Clear();
 
             if (SelectedPage != null)
             {
@@ -1471,13 +1510,13 @@ namespace DSoft.WizardControl
             RecalculateNavigation();
         }
 
-		/// <summary>
-		/// Determines whether this instance can navigate the specified direction.
-		/// </summary>
-		/// <param name="direction">The direction.</param>
-		/// <param name="curItem">The current item.</param>
-		/// <returns><c>true</c> if this instance can navigate the specified direction; otherwise, <c>false</c>.</returns>
-		private bool CanNavigate(NavigationDirection direction, IWizardPage curItem)
+        /// <summary>
+        /// Determines whether this instance can navigate the specified direction.
+        /// </summary>
+        /// <param name="direction">The direction.</param>
+        /// <param name="curItem">The current item.</param>
+        /// <returns><c>true</c> if this instance can navigate the specified direction; otherwise, <c>false</c>.</returns>
+        private bool CanNavigate(NavigationDirection direction, IWizardPage curItem)
         {
             if (curItem.PageConfig.NavigationHandler != null)
             {
@@ -1495,16 +1534,197 @@ namespace DSoft.WizardControl
 
         }
 
-		/// <summary>
-		/// Updates the button visibility.
-		/// </summary>
-		/// <param name="visibility">The visibility.</param>
-		/// <param name="buttons">The buttons.</param>
-		public void UpdateButtonVisibility(WizardButtonVisibility visibility, params WizardButtons[] buttons)
+        /// <summary>
+        /// Retrieves the current style associated with the specified wizard button.
+        /// </summary>
+        /// <param name="button">The wizard button for which to obtain the style.</param>
+        /// <returns>A Style object representing the current style of the specified button. If no specific style is set for the
+        /// button, the default button style is returned.</returns>
+        public Style GetButtonStyle(WizardButtons button)
+        {
+            if (_buttonState.ContainsKey(button))
+            {
+                return _buttonState[button].ButtonStyleCurrent;
+            }
+            else
+            {
+                return ButtonStyle;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves a style resource with the specified key from the control's resources or the application resources.
+        /// </summary>
+        /// <remarks>The method first searches the control's resources for the specified style key. If not
+        /// found, it searches the application-level resources. This allows for both local and global style
+        /// lookups.</remarks>
+        /// <param name="styleKey">The key of the style resource to retrieve. Cannot be null or empty.</param>
+        /// <returns>A Style object associated with the specified key, or null if no matching style is found.</returns>
+        public Style? GetUserControlStyle(string styleKey)
+        {
+            if (string.IsNullOrWhiteSpace(styleKey))
+                return null;
+
+            if (SelectedPage is FrameworkElement selectedPageElement)
+            {
+                var selectedPageStyle = GetStyleFromResourceDictionary(selectedPageElement.Resources, styleKey);
+
+                if (selectedPageStyle != null)
+                    return selectedPageStyle;
+            }
+
+#if WPF
+            if (string.Equals(styleKey, typeof(WizardControl).Name, StringComparison.Ordinal) ||
+                string.Equals(styleKey, typeof(WizardControl).FullName, StringComparison.Ordinal))
+            {
+                var implicitControlStyle = this.TryFindResource(typeof(WizardControl)) as Style;
+                if (implicitControlStyle != null)
+                    return implicitControlStyle;
+            }
+
+            var directStyle = this.TryFindResource(styleKey) as Style;
+            if (directStyle != null)
+                return directStyle;
+#endif
+
+            var style = GetStyleFromResourceDictionary(this.Resources, styleKey);
+
+            if (style != null)
+                return style;
+
+            return GetStyleFromResourceDictionary(Application.Current?.Resources, styleKey);
+        }
+
+        private static Style? GetStyleFromResourceDictionary(ResourceDictionary? resourceDictionary, string styleKey)
+        {
+            if (resourceDictionary == null)
+                return null;
+
+            try
+            {
+                if (resourceDictionary[styleKey] is Style style)
+                    return style;
+            }
+            catch
+            {
+            }
+
+#if WPF
+            foreach (DictionaryEntry entry in resourceDictionary)
+            {
+                if (entry.Value is Style entryStyle)
+                {
+                    if (entry.Key is Type typeKey &&
+                        (string.Equals(typeKey.Name, styleKey, StringComparison.Ordinal) ||
+                         string.Equals(typeKey.FullName, styleKey, StringComparison.Ordinal)))
+                    {
+                        return entryStyle;
+                    }
+                }
+            }
+#endif
+
+            if (resourceDictionary.MergedDictionaries != null)
+            {
+                foreach (var mergedDictionary in resourceDictionary.MergedDictionaries)
+                {
+                    var style = GetStyleFromResourceDictionary(mergedDictionary, styleKey);
+
+                    if (style != null)
+                        return style;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Sets the button style. Use this to set the style of a specific button.  
+        /// If you want to set the style for all buttons, use the WizardButtons.All or ButtonStyle property.
+        /// </summary>
+        /// <param name="button">The button to update.</param>
+        /// <param name="styleKey">The style key (name) to apply.</param>
+        public void UpdateButtonStyle(WizardButtons button, string styleKey)
+        {
+            var style = GetUserControlStyle(styleKey);
+            UpdateButtonStyle(button, style);
+        }
+
+        /// <summary>
+        /// Sets the button style. Use this to set the style of a specific button.  
+        /// If you want to set the style for all buttons, use the WizardButtons.All or ButtonStyle property.
+        /// </summary>
+        /// <param name="button">The button to update.</param>
+        /// <param name="style">The style to apply.</param>
+        public void UpdateButtonStyle(WizardButtons button, Style? style)
+        {
+            if (style == null)
+                return;
+
+            if (button == WizardButtons.All)
+            {
+                // for each button in enumeration aside from .All call UpdateButtonStyleInternal
+                foreach (WizardButtons btn in Enum.GetValues(typeof(WizardButtons)))
+                {
+                    if (btn != WizardButtons.All)
+                    {
+                        UpdateButtonStyleInternal(btn, style);
+                    }
+                }
+            }
+            else
+            {
+                // if it is a specific button, just update that one
+                UpdateButtonStyleInternal(button, style);
+            }
+        }
+
+        /// <summary>
+        /// Sets the button style. Use this to set the style of a specific button (i.e. do not pass WizardButtons.All).  
+        /// If you want to set the style for all buttons, use the ButtonStyle property or 
+        /// UpdateButtonStyle(WizardButtons.All).
+        /// </summary>
+        /// <param name="button">The button to update.</param>
+        /// <param name="style">The style to apply.</param>
+        private void UpdateButtonStyleInternal(WizardButtons button, Style style)
+        {
+            if (_buttonState.ContainsKey(button))
+            {
+                _buttonState[button].ButtonStyleCurrent = style;
+            }
+            else
+            {
+                var buttonState = new WizardButtonState(
+                     button,
+                     WizardButtonVisibility.Visible,
+                     style,
+                     ButtonStyle
+                     );
+                _buttonState.Add(button, buttonState);
+            }
+            // trigger update of the style property for the button to ensure the UI reflects the change
+            var buttonName = Enum.GetName(typeof(WizardButtons), button);
+            var propertyName = buttonName + "ButtonStyle";
+            var dependencyPropertyField = typeof(WizardControl).GetField(
+                propertyName + "Property",
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+
+            if (dependencyPropertyField?.GetValue(null) is DependencyProperty dependencyProperty)
+            {
+                SetValue(dependencyProperty, style);
+            }
+        }
+
+        /// <summary>
+        /// Updates the button visibility.
+        /// </summary>
+        /// <param name="visibility">The visibility.</param>
+        /// <param name="buttons">The buttons.</param>
+        public void UpdateButtonVisibility(WizardButtonVisibility visibility, params WizardButtons[] buttons)
         {
             if (buttons == null || buttons.Length == 0)
             {
-                _buttonVisibility.Clear();
+                _buttonState.Clear();
             }
             else
             {
@@ -1514,7 +1734,7 @@ namespace DSoft.WizardControl
                 //create a local copy of the buttons array
                 var localButtons = new List<WizardButtons>(buttons);
 
-                //if the buttons array conatains WizardButtons.All, rebuild the localbuttons variable all the buttons.  TODO:// This could be update to loop through the Enum instead of being hardcoded
+                //if the buttons array contains WizardButtons.All, rebuild the localbuttons variable all the buttons.  TODO:// This could be update to loop through the Enum instead of being hardcoded
                 if (buttons.Contains(WizardButtons.All))
                 {
                     localButtons = new List<WizardButtons>() { WizardButtons.Cancel, WizardButtons.Complete, WizardButtons.Next, WizardButtons.Previous, WizardButtons.Process };
@@ -1524,13 +1744,19 @@ namespace DSoft.WizardControl
                 foreach (var button in localButtons)
                 {
                     //if all buttons use hide not collapsed when hiding all buttons
-                    if (_buttonVisibility.ContainsKey(button))
+                    if (_buttonState.ContainsKey(button))
                     {
-                        _buttonVisibility[button] = realVisibilty;
+                        _buttonState[button].GUIVisibility = realVisibilty;
                     }
                     else
                     {
-                        _buttonVisibility.Add(button, realVisibilty);
+                        var buttonState = new WizardButtonState(
+                            button,
+                            WizardButtonVisibility.Visible,
+                            ButtonStyle,
+                            ButtonStyle
+                        );
+                        _buttonState.Add(button, buttonState);
                     }
                 }
             }
@@ -1538,21 +1764,21 @@ namespace DSoft.WizardControl
             RecalculateNavigation();
         }
 
-		/// <summary>
-		/// Updates the stage.
-		/// </summary>
-		/// <param name="stage">The stage.</param>
-		public void UpdateStage(WizardStage stage)
+        /// <summary>
+        /// Updates the stage.
+        /// </summary>
+        /// <param name="stage">The stage.</param>
+        public void UpdateStage(WizardStage stage)
         {
             _currentStage = stage;
 
             RecalculateNavigation();
         }
 
-		/// <summary>
-		/// Recalculates the navigation.
-		/// </summary>
-		public void RecalculateNavigation()
+        /// <summary>
+        /// Recalculates the navigation.
+        /// </summary>
+        public void RecalculateNavigation()
         {
             var subTitle = string.Empty;
 
@@ -1563,7 +1789,7 @@ namespace DSoft.WizardControl
                 if (SelectedIndex < 0)
                     page = Pages[0];
                 else
-					page = Pages[SelectedIndex];
+                    page = Pages[SelectedIndex];
 
                 if (page != null)
                 {
@@ -1585,9 +1811,9 @@ namespace DSoft.WizardControl
             //calculate visibility after enabled status
             var buttonStackVisibility = Visibility.Visible;
 
-            if (_buttonVisibility.ContainsKey(WizardButtons.All))
+            if (_buttonState.ContainsKey(WizardButtons.All))
             {
-                buttonStackVisibility = _buttonVisibility[WizardButtons.All];
+                buttonStackVisibility = _buttonState[WizardButtons.All].GUIVisibility;
             }
             else if (SelectedPage != null)
             {
@@ -1606,12 +1832,12 @@ namespace DSoft.WizardControl
             SubTitle = SubTitle;
         }
 
-		/// <summary>
-		/// Gets the index of the previous page.
-		/// </summary>
-		/// <param name="currentIndex">Index of the current.</param>
-		/// <returns>System.Int32.</returns>
-		private int GetPreviousPageIndex(int currentIndex)
+        /// <summary>
+        /// Gets the index of the previous page.
+        /// </summary>
+        /// <param name="currentIndex">Index of the current.</param>
+        /// <returns>System.Int32.</returns>
+        private int GetPreviousPageIndex(int currentIndex)
         {
             if (currentIndex == 0)
                 return currentIndex;
@@ -1625,12 +1851,12 @@ namespace DSoft.WizardControl
             return newIndex;
         }
 
-		/// <summary>
-		/// Gets the index of the next page.
-		/// </summary>
-		/// <param name="currentIndex">Index of the current.</param>
-		/// <returns>System.Int32.</returns>
-		private int GetNextPageIndex(int currentIndex)
+        /// <summary>
+        /// Gets the index of the next page.
+        /// </summary>
+        /// <param name="currentIndex">Index of the current.</param>
+        /// <returns>System.Int32.</returns>
+        private int GetNextPageIndex(int currentIndex)
         {
             if (currentIndex == ActivePages.Max(x => x.Key))
                 return currentIndex;
@@ -1643,12 +1869,12 @@ namespace DSoft.WizardControl
             return newIndex;
         }
 
-		/// <summary>
-		/// Replaces the page.
-		/// </summary>
-		/// <param name="oldPage">The old page.</param>
-		/// <param name="newPage">The new page.</param>
-		private void ReplacePage(IWizardPage oldPage, IWizardPage newPage)
+        /// <summary>
+        /// Replaces the page.
+        /// </summary>
+        /// <param name="oldPage">The old page.</param>
+        /// <param name="newPage">The new page.</param>
+        private void ReplacePage(IWizardPage oldPage, IWizardPage newPage)
         {
 
             if (Pages.Contains(oldPage))
@@ -1669,7 +1895,7 @@ namespace DSoft.WizardControl
 
         }
 
-#endregion
+        #endregion
 
 
     }

--- a/DSoft.WizardControl.WinUI/WizardControl.uwp.winui.wpf.cs
+++ b/DSoft.WizardControl.WinUI/WizardControl.uwp.winui.wpf.cs
@@ -29,12 +29,12 @@ namespace DSoft.WizardControl
     public class WizardControl : Control, IWizardControl
     {
         #region Controls
-        private ContentControl _contentGrid;
-        private Button _btnNext;
-        private Button _btnPrevious;
-        private Button _btnCancel;
-        private Button _btnFinish;
-        private Button _btnComplete;
+        private ContentControl? _contentGrid;
+        private Button? _btnNext;
+        private Button? _btnPrevious;
+        private Button? _btnCancel;
+        private Button? _btnFinish;
+        private Button? _btnComplete;
 
         #endregion
         private WizardStage _currentStage = WizardStage.Setup;
@@ -960,7 +960,7 @@ namespace DSoft.WizardControl
         /// Gets the available pages.
         /// </summary>
         /// <value>The available pages.</value>
-        public List<IWizardPage> AvailablePages => Pages?.ToList();
+        public List<IWizardPage> AvailablePages => Pages?.ToList() ?? new List<IWizardPage>();
 
         #endregion
 
@@ -1361,11 +1361,16 @@ namespace DSoft.WizardControl
             });
 
 #if WINUI
-            _btnNext.Command = NextCommand;
-            _btnPrevious.Command = PreviousCommand;
-            _btnCancel.Command = CancelCommand;
-            _btnComplete.Command = CompleteCommand;
-            _btnFinish.Command = ProcessButtonCommand;
+            if (_btnNext != null)
+                _btnNext.Command = NextCommand;
+            if (_btnPrevious != null)
+                _btnPrevious.Command = PreviousCommand;
+            if (_btnCancel != null)
+                _btnCancel.Command = CancelCommand;
+            if (_btnComplete != null)
+                _btnComplete.Command = CompleteCommand;
+            if (_btnFinish != null)
+                _btnFinish.Command = ProcessButtonCommand;
 #endif
 
             if (Pages != null)
@@ -1473,7 +1478,8 @@ namespace DSoft.WizardControl
         {
             if (Pages == null || Pages.Count == 0)
             {
-                _contentGrid.Content = ProcessingPage;
+                if (_contentGrid != null)
+                    _contentGrid.Content = ProcessingPage;
 
                 return;
             }
@@ -1793,7 +1799,7 @@ namespace DSoft.WizardControl
 
                 if (page != null)
                 {
-                    subTitle = page.PageConfig?.Title;
+                    subTitle = page.PageConfig?.Title ?? string.Empty;
                 }
             }
 

--- a/DSoft.WizardControl.WinUI/WizardControl.uwp.winui.wpf.cs
+++ b/DSoft.WizardControl.WinUI/WizardControl.uwp.winui.wpf.cs
@@ -284,7 +284,21 @@ namespace DSoft.WizardControl
         {
             get
             {
-                return ActivePages.Max(x => x.Key);
+                var pages = Pages;
+                if (pages == null)
+                    return -1;
+
+                var processingPage = ProcessingPage;
+                var completePage = CompletePage;
+                var errorPage = ErrorPage;
+
+                for (int i = pages.Count - 1; i >= 0; i--)
+                {
+                    if (IsActivePage(pages[i], processingPage, completePage, errorPage))
+                        return i;
+                }
+
+                return -1;
             }
         }
 
@@ -298,20 +312,36 @@ namespace DSoft.WizardControl
             {
                 var aDict = new Dictionary<int, IWizardPage>();
 
+                var pages = Pages;
+                if (pages == null)
+                    return aDict;
 
-                var aPages = Pages.Where(x => x != null && x.PageConfig != null && x.PageConfig.IsHidden.Equals(false) && (!x.Equals(ProcessingPage) && !x.Equals(CompletePage) && !x.Equals(ErrorPage)));
+                var processingPage = ProcessingPage;
+                var completePage = CompletePage;
+                var errorPage = ErrorPage;
 
-                if (aPages.Any())
+                for (int i = 0; i < pages.Count; i++)
                 {
-                    foreach (var aPage in aPages)
-                    {
-                        aDict.Add(Pages.IndexOf(aPage), aPage);
-                    }
+                    var aPage = pages[i];
+                    if (IsActivePage(aPage, processingPage, completePage, errorPage))
+                        aDict.Add(i, aPage);
                 }
-
 
                 return aDict;
             }
+        }
+
+        /// <summary>
+        /// Determines whether the page participates in navigation (visible and not a special page).
+        /// </summary>
+        private static bool IsActivePage(IWizardPage? page, IWizardPage? processingPage, IWizardPage? completePage, IWizardPage? errorPage)
+        {
+            return page != null
+                && page.PageConfig != null
+                && !page.PageConfig.IsHidden
+                && !page.Equals(processingPage)
+                && !page.Equals(completePage)
+                && !page.Equals(errorPage);
         }
 
         /// <summary>
@@ -974,7 +1004,7 @@ namespace DSoft.WizardControl
         {
             get
             {
-                if (Pages.Count == 0 || ActivePages.Count == 0)
+                if (Pages.Count == 0 || LastActivePageIndex < 0)
                     return false;
 
                 switch (_currentStage)
@@ -1007,7 +1037,7 @@ namespace DSoft.WizardControl
         {
             get
             {
-                if (Pages.Count == 0 || ActivePages.Count == 0)
+                if (Pages.Count == 0 || LastActivePageIndex < 0)
                     return false;
 
                 switch (_currentStage)
@@ -1021,7 +1051,7 @@ namespace DSoft.WizardControl
                         return false;
 
                     default:
-                        return SelectedIndex != ActivePages.Max(x => x.Key);
+                        return SelectedIndex != LastActivePageIndex;
                 }
 
 
@@ -1036,7 +1066,7 @@ namespace DSoft.WizardControl
         {
             get
             {
-                if (Pages.Count == 0 || ActivePages.Count == 0)
+                if (Pages.Count == 0 || LastActivePageIndex < 0)
                     return false;
 
                 if (ProcessMode == ProcessMode.None)
@@ -1051,7 +1081,7 @@ namespace DSoft.WizardControl
                         return false;
 
                     default:
-                        return SelectedIndex == ActivePages.Max(x => x.Key);
+                        return SelectedIndex == LastActivePageIndex;
                 }
 
 
@@ -1066,12 +1096,12 @@ namespace DSoft.WizardControl
         {
             get
             {
-                if (Pages.Count == 0 || ActivePages.Count == 0)
+                if (Pages.Count == 0 || LastActivePageIndex < 0)
                     return false;
 
                 if (ProcessMode == ProcessMode.None)
                 {
-                    if (SelectedIndex == ActivePages.Max(x => x.Key))
+                    if (SelectedIndex == LastActivePageIndex)
                         return false;
                 }
                 switch (_currentStage)
@@ -1095,12 +1125,12 @@ namespace DSoft.WizardControl
         {
             get
             {
-                if (Pages.Count == 0 || ActivePages.Count == 0)
+                if (Pages.Count == 0 || LastActivePageIndex < 0)
                     return false;
 
                 if (ProcessMode == ProcessMode.None)
                 {
-                    if (SelectedIndex == ActivePages.Max(x => x.Key))
+                    if (SelectedIndex == LastActivePageIndex)
                         return true;
                 }
 
@@ -1864,7 +1894,7 @@ namespace DSoft.WizardControl
         /// <returns>System.Int32.</returns>
         private int GetNextPageIndex(int currentIndex)
         {
-            if (currentIndex == ActivePages.Max(x => x.Key))
+            if (currentIndex == LastActivePageIndex)
                 return currentIndex;
 
             var newIndex = currentIndex + 1;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,7 @@
 		<LangVersion>Latest</LangVersion>
 		<Configurations>Debug;Release</Configurations>
 		<NoWarn>1701;1702;CS8002</NoWarn>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Dsoft.WizardControl/DSoft.WizardControl.csproj
+++ b/Dsoft.WizardControl/DSoft.WizardControl.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0-windows7.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0-windows7.0;net10.0-windows</TargetFrameworks>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/WinUISample/App.xaml.cs
+++ b/WinUISample/App.xaml.cs
@@ -46,6 +46,6 @@ namespace WinUISample
             m_window.AppWindow.Resize(new Windows.Graphics.SizeInt32(1024, 768));
         }
 
-        private Window m_window;
+        private Window m_window = null!;
     }
 }

--- a/WinUISample/MainPage.xaml.cs
+++ b/WinUISample/MainPage.xaml.cs
@@ -23,7 +23,7 @@ namespace WinUISample
     /// </summary>
     public sealed partial class MainPage : Page
     {
-        private MainWindowViewModel _viewModel;
+        private MainWindowViewModel _viewModel = null!;
 
         public MainWindowViewModel ViewModel
         {
@@ -39,7 +39,7 @@ namespace WinUISample
             ViewModel.OnRequestCloseWindow += OnCloseWindowRequest;
         }
 
-        private void OnCloseWindowRequest(object sender, bool e)
+        private void OnCloseWindowRequest(object? sender, bool e)
         {
             
         }

--- a/WinUISample/MainWindowViewModel.cs
+++ b/WinUISample/MainWindowViewModel.cs
@@ -15,16 +15,16 @@ namespace WinUISample
     public class MainWindowViewModel : ViewModel
     {
         #region Fields
-        private SharedViewModel _sharedViewModel;
-        private ObservableCollection<IWizardPage> _pages;
-        private string _title;
-        private IWizardPage _completePage;
-        private IWizardPage _errorPage;
-        private IWizardPage _processingPage;
-        private IWizardPage _selectedPage;
+        private SharedViewModel _sharedViewModel = null!;
+        private ObservableCollection<IWizardPage> _pages = null!;
+        private string _title = null!;
+        private IWizardPage _completePage = null!;
+        private IWizardPage _errorPage = null!;
+        private IWizardPage _processingPage = null!;
+        private IWizardPage _selectedPage = null!;
         #endregion
 
-        public event EventHandler<bool> OnRequestCloseWindow;
+        public event EventHandler<bool>? OnRequestCloseWindow;
 
         public string Title
         {

--- a/WinUISample/TestData/Pages/CompletePageView.xaml.cs
+++ b/WinUISample/TestData/Pages/CompletePageView.xaml.cs
@@ -22,7 +22,7 @@ namespace WinUISample.TestData.Pages
 {
     public sealed partial class CompletePageView : UserControl, IWizardPage
     {
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
 
         public SharedViewModel ViewModel
         {

--- a/WinUISample/TestData/Pages/ErrorPage.xaml.cs
+++ b/WinUISample/TestData/Pages/ErrorPage.xaml.cs
@@ -22,7 +22,7 @@ namespace WinUISample.TestData.Pages
 {
     public sealed partial class ErrorPage : UserControl, IWizardPage
     {
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
 
         public SharedViewModel ViewModel
         {

--- a/WinUISample/TestData/Pages/PageOne.xaml
+++ b/WinUISample/TestData/Pages/PageOne.xaml
@@ -8,6 +8,14 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ms-appx:///Themes/Generic.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
     <Grid Margin="10">
         <StackPanel>
             <TextBlock>Code</TextBlock>

--- a/WinUISample/TestData/Pages/PageOne.xaml.cs
+++ b/WinUISample/TestData/Pages/PageOne.xaml.cs
@@ -48,7 +48,7 @@ namespace WinUISample.TestData.Pages
         public void OnShown(IWizardControl wizard)
         {
             //wizard.SetButtonVisibility(WizardButtonVisibility.Hidden, WizardButtons.All);
-
+            wizard.UpdateButtonStyle(WizardButtons.Next, "WizardTestRedButtonStyle");
         }
 
         public Task<bool> ValidateAsync()

--- a/WinUISample/TestData/Pages/PageOne.xaml.cs
+++ b/WinUISample/TestData/Pages/PageOne.xaml.cs
@@ -22,7 +22,7 @@ namespace WinUISample.TestData.Pages
 {
     public sealed partial class PageOne : UserControl, IWizardPage
     {
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
         private IWizardControl _wizardControl;
 
         public SharedViewModel ViewModel

--- a/WinUISample/TestData/Pages/PageThree.xaml.cs
+++ b/WinUISample/TestData/Pages/PageThree.xaml.cs
@@ -22,7 +22,7 @@ namespace WinUISample.TestData.Pages
 {
     public sealed partial class PageThree : UserControl, IWizardPage
     {
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
 
         public SharedViewModel ViewModel
         {

--- a/WinUISample/TestData/Pages/PageTwo.xaml.cs
+++ b/WinUISample/TestData/Pages/PageTwo.xaml.cs
@@ -22,7 +22,7 @@ namespace WinUISample.TestData.Pages
 {
     public sealed partial class PageTwo : UserControl, IWizardPage
     {
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
 
         public SharedViewModel ViewModel
         {

--- a/WinUISample/TestData/Pages/ProcessingPage.xaml.cs
+++ b/WinUISample/TestData/Pages/ProcessingPage.xaml.cs
@@ -22,7 +22,7 @@ namespace WinUISample.TestData.Pages
 {
     public sealed partial class ProcessingPage : UserControl, IWizardPage
     {
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
 
         public SharedViewModel ViewModel
         {

--- a/WinUISample/TestData/SharedViewModel.cs
+++ b/WinUISample/TestData/SharedViewModel.cs
@@ -11,9 +11,9 @@ namespace WinUISample.TestData
 {
     public class SharedViewModel : ViewModel
     {
-        private string _code;
-        private string _bankAccountName;
-        private string datbaseName;
+        private string _code = null!;
+        private string _bankAccountName = null!;
+        private string datbaseName = null!;
         private IWizardControl _wizardControl;
 
         public string Code
@@ -42,7 +42,7 @@ namespace WinUISample.TestData
             set { _hidePage2 = value; NotifyPropertyChanged(nameof(HidePage2)); _wizardControl.RecalculateNavigation(); }
         }
 
-        public Action MoveNextAction { get; set; }
+        public Action? MoveNextAction { get; set; }
 
         public ICommand MoveNextPageCommand
         {

--- a/WinUISample/Themes/Generic.xaml
+++ b/WinUISample/Themes/Generic.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style x:Key="WizardTestBlueButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="#FF0078D7" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="BorderBrush" Value="#FF005A9E" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="16,8" />
+    </Style>
+
+    <Style x:Key="WizardTestRedButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="#FFD13438" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="BorderBrush" Value="#FFA4262C" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="16,8" />
+    </Style>
+
+</ResourceDictionary>

--- a/WinUISample/WinUISample.csproj
+++ b/WinUISample/WinUISample.csproj
@@ -35,9 +35,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DSoft.System.Mvvm" Version="3.5.2604.111" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
+		<PackageReference Include="DSoft.System.Mvvm" Version="3.6.2606.131" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 
@@ -87,7 +87,7 @@
 			<Generator>MSBuild:Compile</Generator>
 		</Page>
 	</ItemGroup>
- <ItemGroup>
+	<ItemGroup>
 		<Page Update="Themes\Generic.xaml">
 			<Generator>MSBuild:Compile</Generator>
 		</Page>

--- a/WinUISample/WinUISample.csproj
+++ b/WinUISample/WinUISample.csproj
@@ -13,18 +13,17 @@
 		<SignAssembly>false</SignAssembly>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-		<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+		<WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
 	</PropertyGroup>
 	<ItemGroup>
-	  <None Remove="MainPage.xaml" />
-	  <None Remove="TestData\Pages\CompletePageView.xaml" />
-	  <None Remove="TestData\Pages\ErrorPage.xaml" />
-	  <None Remove="TestData\Pages\PageOne.xaml" />
-	  <None Remove="TestData\Pages\PageThree.xaml" />
-	  <None Remove="TestData\Pages\PageTwo.xaml" />
-	  <None Remove="TestData\Pages\ProcessingPage.xaml" />
+		<None Remove="MainPage.xaml" />
+		<None Remove="TestData\Pages\CompletePageView.xaml" />
+		<None Remove="TestData\Pages\ErrorPage.xaml" />
+		<None Remove="TestData\Pages\PageOne.xaml" />
+		<None Remove="TestData\Pages\PageThree.xaml" />
+		<None Remove="TestData\Pages\PageTwo.xaml" />
+		<None Remove="TestData\Pages\ProcessingPage.xaml" />
 	</ItemGroup>
-
 	<ItemGroup>
 		<Content Include="Assets\SplashScreen.scale-200.png" />
 		<Content Include="Assets\LockScreenLogo.scale-200.png" />
@@ -36,9 +35,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DSoft.System.Mvvm" Version="3.3.2405.241" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240607001" />
+		<PackageReference Include="DSoft.System.Mvvm" Version="3.5.2604.111" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 
@@ -51,42 +50,47 @@
 		<ProjectCapability Include="Msix" />
 	</ItemGroup>
 	<ItemGroup>
-	  <ProjectReference Include="..\DSoft.WizardControl.WinUI\DSoft.WizardControl.WinUI.csproj" />
+		<ProjectReference Include="..\DSoft.WizardControl.WinUI\DSoft.WizardControl.WinUI.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-	  <Page Update="MainPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Page>
+		<Page Update="MainPage.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
 	</ItemGroup>
 	<ItemGroup>
-	  <Page Update="TestData\Pages\ProcessingPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Page>
+		<Page Update="TestData\Pages\ProcessingPage.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
 	</ItemGroup>
 	<ItemGroup>
-	  <Page Update="TestData\Pages\PageTwo.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Page>
+		<Page Update="TestData\Pages\PageTwo.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
 	</ItemGroup>
 	<ItemGroup>
-	  <Page Update="TestData\Pages\PageThree.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Page>
+		<Page Update="TestData\Pages\PageThree.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
 	</ItemGroup>
 	<ItemGroup>
-	  <Page Update="TestData\Pages\PageOne.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Page>
+		<Page Update="TestData\Pages\PageOne.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
 	</ItemGroup>
 	<ItemGroup>
-	  <Page Update="TestData\Pages\ErrorPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Page>
+		<Page Update="TestData\Pages\ErrorPage.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
 	</ItemGroup>
 	<ItemGroup>
-	  <Page Update="TestData\Pages\CompletePageView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Page>
+		<Page Update="TestData\Pages\CompletePageView.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
+	</ItemGroup>
+ <ItemGroup>
+		<Page Update="Themes\Generic.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
 	</ItemGroup>
 
 	<!--

--- a/WpfAppNetCore/MainWindow.xaml.cs
+++ b/WpfAppNetCore/MainWindow.xaml.cs
@@ -20,7 +20,7 @@ namespace WpfAppNetCore
     /// </summary>
     public partial class MainWindow : Window
     {
-        private MainWindowViewModel _viewModel;
+        private MainWindowViewModel _viewModel = null!;
 
         public MainWindowViewModel ViewModel
         {
@@ -37,7 +37,7 @@ namespace WpfAppNetCore
 			ViewModel.OnRequestCloseWindow += OnCloseWindowRequest;
         }
 
-        private void OnCloseWindowRequest(object sender, bool e)
+        private void OnCloseWindowRequest(object? sender, bool e)
         {
             this.Close();
         }

--- a/WpfAppNetCore/MainWindowViewModel.cs
+++ b/WpfAppNetCore/MainWindowViewModel.cs
@@ -16,16 +16,16 @@ namespace WpfAppNetCore
     public class MainWindowViewModel : ViewModel
     {
         #region Fields
-        private SharedViewModel _sharedViewModel;
-        private ObservableCollection<IWizardPage> _pages;
-        private string _title;
-        private IWizardPage _completePage;
-        private IWizardPage _errorPage;
-        private IWizardPage _processingPage;
-        private IWizardPage _selectedPage;
+        private SharedViewModel _sharedViewModel = null!;
+        private ObservableCollection<IWizardPage> _pages = null!;
+        private string _title = null!;
+        private IWizardPage _completePage = null!;
+        private IWizardPage _errorPage = null!;
+        private IWizardPage _processingPage = null!;
+        private IWizardPage _selectedPage = null!;
         #endregion
 
-        public event EventHandler<bool> OnRequestCloseWindow;
+        public event EventHandler<bool>? OnRequestCloseWindow;
 
         public string Title
         {

--- a/WpfAppNetCore/TestData/Pages/CompletePageView.xaml.cs
+++ b/WpfAppNetCore/TestData/Pages/CompletePageView.xaml.cs
@@ -22,7 +22,7 @@ namespace WpfAppNetCore.TestData.Pages
     public partial class CompletePageView : UserControl, IWizardPage
     {
 
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
 
 
         public SharedViewModel ViewModel

--- a/WpfAppNetCore/TestData/Pages/ErrorPage.xaml.cs
+++ b/WpfAppNetCore/TestData/Pages/ErrorPage.xaml.cs
@@ -22,7 +22,7 @@ namespace WpfAppNetCore.TestData.Pages
     public partial class ErrorPage : UserControl, IWizardPage
     {
 
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
 
 
         public SharedViewModel ViewModel

--- a/WpfAppNetCore/TestData/Pages/PageOne.xaml
+++ b/WpfAppNetCore/TestData/Pages/PageOne.xaml
@@ -5,12 +5,20 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Themes/Generic.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
     <Grid Margin="10">
         <StackPanel>
             <TextBlock>Code</TextBlock>
             <TextBox Text="{Binding Code, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
             <CheckBox IsChecked="{Binding HidePage2, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">Hide Page 2</CheckBox>
             <Button Content="Finish" Command="{Binding SetFinishCommand}" />
+            <Button Content="Test" Style="{StaticResource WizardTestRedButtonStyle}"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/WpfAppNetCore/TestData/Pages/PageOne.xaml.cs
+++ b/WpfAppNetCore/TestData/Pages/PageOne.xaml.cs
@@ -48,6 +48,7 @@ namespace WpfAppNetCore.TestData.Pages
         public void OnShown(IWizardControl wizard)
         {
             //wizard.SetButtonVisibility(WizardButtonVisibility.Hidden, WizardButtons.All);
+            wizard.UpdateButtonStyle(WizardButtons.Next, "WizardTestRedButtonStyle");
 
         }
 

--- a/WpfAppNetCore/TestData/Pages/PageOne.xaml.cs
+++ b/WpfAppNetCore/TestData/Pages/PageOne.xaml.cs
@@ -22,7 +22,7 @@ namespace WpfAppNetCore.TestData.Pages
     public partial class PageOne : UserControl, IWizardPage
     {
 
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
         private IWizardControl _wizardControl;
 
         public SharedViewModel ViewModel

--- a/WpfAppNetCore/TestData/Pages/PageThree.xaml.cs
+++ b/WpfAppNetCore/TestData/Pages/PageThree.xaml.cs
@@ -21,7 +21,7 @@ namespace WpfAppNetCore.TestData.Pages
     /// </summary>
     public partial class PageThree : UserControl, IWizardPage
     {
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
 
         public SharedViewModel ViewModel
         {

--- a/WpfAppNetCore/TestData/Pages/PageTwo.xaml.cs
+++ b/WpfAppNetCore/TestData/Pages/PageTwo.xaml.cs
@@ -21,7 +21,7 @@ namespace WpfAppNetCore.TestData.Pages
     /// </summary>
     public partial class PageTwo : UserControl, IWizardPage
     {
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
 
         public SharedViewModel ViewModel
         {

--- a/WpfAppNetCore/TestData/Pages/ProcessingPage.xaml.cs
+++ b/WpfAppNetCore/TestData/Pages/ProcessingPage.xaml.cs
@@ -22,7 +22,7 @@ namespace WpfAppNetCore.TestData.Pages
     public partial class ProcessingPage : UserControl, IWizardPage
     {
 
-        private SharedViewModel _viewModel;
+        private SharedViewModel _viewModel = null!;
 
 
         public SharedViewModel ViewModel

--- a/WpfAppNetCore/TestData/SharedViewModel.cs
+++ b/WpfAppNetCore/TestData/SharedViewModel.cs
@@ -11,9 +11,9 @@ namespace WpfAppNetCore.TestData
 {
     public class SharedViewModel : ViewModel
     {
-        private string _code;
-        private string _bankAccountName;
-        private string datbaseName;
+        private string _code = null!;
+        private string _bankAccountName = null!;
+        private string datbaseName = null!;
         private IWizardControl _wizardControl;
 
         public string Code
@@ -42,7 +42,7 @@ namespace WpfAppNetCore.TestData
             set { _hidePage2 = value; NotifyPropertyChanged(nameof(HidePage2)); _wizardControl.RecalculateNavigation(); }
         }
 
-        public Action MoveNextAction { get; set; }
+        public Action? MoveNextAction { get; set; }
 
         public ICommand MoveNextPageCommand
         {

--- a/WpfAppNetCore/WpfAppNetCore.csproj
+++ b/WpfAppNetCore/WpfAppNetCore.csproj
@@ -9,56 +9,64 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="DSoft.System.Mvvm" Version="3.3.2405.241" />
-    <PackageReference Include="MahApps.Metro" Version="2.4.10" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="DSoft.System.Mvvm" Version="3.5.2604.111" />
+		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DSoft.WizardControl.WPF\DSoft.WizardControl.WPF.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\DSoft.WizardControl.WPF\DSoft.WizardControl.WPF.csproj" />
+	</ItemGroup>
 
 
-  <ItemGroup>
-    <Compile Update="TestData\Pages\CompletePageView.xaml.cs">
-      <DependentUpon>CompletePageView.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="TestData\Pages\ErrorPage.xaml.cs">
-      <DependentUpon>ErrorPage.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="TestData\Pages\PageOne.xaml.cs">
-      <DependentUpon>PageOne.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="TestData\Pages\PageThree.xaml.cs">
-      <DependentUpon>PageThree.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="TestData\Pages\PageTwo.xaml.cs">
-      <DependentUpon>PageTwo.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="TestData\Pages\ProcessingPage.xaml.cs">
-      <DependentUpon>ProcessingPage.xaml</DependentUpon>
-    </Compile>
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Update="TestData\Pages\CompletePageView.xaml.cs">
+			<DependentUpon>CompletePageView.xaml</DependentUpon>
+		</Compile>
+		<Compile Update="TestData\Pages\ErrorPage.xaml.cs">
+			<DependentUpon>ErrorPage.xaml</DependentUpon>
+		</Compile>
+		<Compile Update="TestData\Pages\PageOne.xaml.cs">
+			<DependentUpon>PageOne.xaml</DependentUpon>
+		</Compile>
+		<Compile Update="TestData\Pages\PageThree.xaml.cs">
+			<DependentUpon>PageThree.xaml</DependentUpon>
+		</Compile>
+		<Compile Update="TestData\Pages\PageTwo.xaml.cs">
+			<DependentUpon>PageTwo.xaml</DependentUpon>
+		</Compile>
+		<Compile Update="TestData\Pages\ProcessingPage.xaml.cs">
+			<DependentUpon>ProcessingPage.xaml</DependentUpon>
+		</Compile>
+	</ItemGroup>
 
-  <ItemGroup>
-    <Page Update="TestData\Pages\CompletePageView.xaml">
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Update="TestData\Pages\ErrorPage.xaml">
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Update="TestData\Pages\PageOne.xaml">
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Update="TestData\Pages\PageThree.xaml">
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Update="TestData\Pages\PageTwo.xaml">
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Update="TestData\Pages\ProcessingPage.xaml">
-      <SubType>Designer</SubType>
-    </Page>
-  </ItemGroup>
+	<ItemGroup>
+		<Page Update="TestData\Pages\CompletePageView.xaml">
+			<SubType>Designer</SubType>
+		</Page>
+		<Page Update="TestData\Pages\ErrorPage.xaml">
+			<SubType>Designer</SubType>
+		</Page>
+		<Page Update="TestData\Pages\PageOne.xaml">
+			<SubType>Designer</SubType>
+		</Page>
+		<Page Update="TestData\Pages\PageThree.xaml">
+			<SubType>Designer</SubType>
+		</Page>
+		<Page Update="TestData\Pages\PageTwo.xaml">
+			<SubType>Designer</SubType>
+		</Page>
+		<Page Update="TestData\Pages\ProcessingPage.xaml">
+			<SubType>Designer</SubType>
+		</Page>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Folder Include="Themes\" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Page Include="..\WinUISample\Themes\Generic.xaml" Link="Themes\Generic.xaml" />
+	</ItemGroup>
 
 </Project>

--- a/WpfAppNetCore/WpfAppNetCore.csproj
+++ b/WpfAppNetCore/WpfAppNetCore.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFramework>net10.0-Windows7.0</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <SignAssembly>false</SignAssembly>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFramework>net10.0-Windows7.0</TargetFramework>
+		<UseWPF>true</UseWPF>
+		<SignAssembly>false</SignAssembly>
+		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DSoft.System.Mvvm" Version="3.5.2604.111" />
+		<PackageReference Include="DSoft.System.Mvvm" Version="3.6.2606.131" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 	</ItemGroup>
 
@@ -62,11 +62,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Folder Include="Themes\" />
+		<Folder Include="Themes\" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Page Include="..\WinUISample\Themes\Generic.xaml" Link="Themes\Generic.xaml" />
+		<Page Include="..\WinUISample\Themes\Generic.xaml" Link="Themes\Generic.xaml" />
 	</ItemGroup>
 
 </Project>

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -22,7 +22,7 @@ variables:
   netVersion: '10.x'
   releaseSuffix: ''
 
-name: 3.0.$(date:yyMM).$(date:dd)$(rev:r)
+name: 3.1.$(date:yyMM).$(date:dd)$(rev:r)
 steps:
 - task: NuGetToolInstaller@1
   displayName: Install Latest Nuget


### PR DESCRIPTION
## Summary

Two related changes on `dev`:

### Enable nullable reference types
- Turn on `<Nullable>enable</Nullable>` in `Directory.Build.props` and resolve all resulting CS86xx warnings across the library and sample projects.
- **Library:** `WizardPageConfiguration` title/handlers nullable; `DelegateCommand` matches `ICommand` signatures (`object?`) with nullable fields/delegates/`ExecuteChanged`; `WizardControl` template-child fields nullable with null-guarded access, plus `AvailablePages`/subtitle fallbacks.
- **Samples (WpfAppNetCore, WinUISample):** `null!` on constructor-assigned fields; nullable event/`MoveNextAction`; `object?` event sender parameters.

### Optimise WizardControl navigation hot path
- `RecalculateNavigation` previously rebuilt `ActivePages` ~10 times per call, each an O(n^2) scan with a `Dictionary` allocation.
- `ActivePages` getter: O(n^2) -> O(n), removed double enumeration.
- `LastActivePageIndex`: allocation-free reverse scan instead of `ActivePages.Max(x => x.Key)`.
- Replaced `ActivePages.Max` / `ActivePages.Count == 0` call sites (incl. `GetNextPageIndex` recursion) with `LastActivePageIndex`.
- Net: zero dict allocations, all O(n). Behaviour preserved; public `ActivePages` API unchanged.

## Test plan
- `dotnet build Dsoft.WizardControl.slnx -c Debug` — build succeeds, zero warnings across both WPF and WINUI define paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)